### PR TITLE
Changing the batch settings for the logger.  Reducing the batches to …

### DIFF
--- a/helpers/helper_full_order.php
+++ b/helpers/helper_full_order.php
@@ -59,6 +59,9 @@ function get_full_order($partial, $mysql, $overwrite_rx_messages = false) {
   usort($order, 'sort_order_by_day'); //Put Rxs in order (with Rx_Source) at the top
   $order = add_wc_status_to_order($order);
 
+  die();
+
+
   return $order;
 }
 

--- a/helpers/helper_logger.php
+++ b/helpers/helper_logger.php
@@ -11,4 +11,4 @@ use Sirum\Logging\SirumLog;
  * This shouldn't be here.  When this moves into a standalone class,
  * we will rework it.
  */
-SirumLog::getLogger('pharmacy-automation');
+SirumLog::getLogger('dev-pharmacy-automation');


### PR DESCRIPTION
…50 log entries and 4 threads.  Should create smaller numbers of failures and reduce impact of a failed report.