### PR TITLE
Squash a bunch of PHP notices.

### DIFF
--- a/classes/Sirum/Logging/SirumLog.php
+++ b/classes/Sirum/Logging/SirumLog.php
@@ -51,7 +51,12 @@ class SirumLog
             self::getLogger();
         }
 
-        list($message, $context) = $args;
+        if (is_array($args)) {
+            list($message, $context) = $args;
+        } else {
+            $message = $args;
+            $context = [];
+        }
 
         $context = ["context" => $context];
 

--- a/helpers/helper_appsscripts.php
+++ b/helpers/helper_appsscripts.php
@@ -37,8 +37,19 @@ function gdoc_post($url, $content)
     $results = file_get_contents($url.'?GD_KEY='.GD_KEY, false, $context);
 
     $ids = @$content['ids'][0]; //to differentiate between removeCalendarEvents
+    // Lots of squelching so we don't need so many ifs
 
-    $global_exec_details['timers_gd']["$content[method] $content[file]$content[word_search]$content[title]$ids"] = ceil(microtime(true) - $start);
+    $key_fields = [
+        @$content['method'],
+        @$content['file'],
+        @$content['word_search'],
+        @$content[title],
+        @$content['ids'][0]
+    ];
+
+    $key = implode(' ', $key_fields);
+
+    $global_exec_details['timers_gd'][$key] = ceil(microtime(true) - $start);
 
     return $results;
 }

--- a/helpers/helper_calendar.php
+++ b/helpers/helper_calendar.php
@@ -4,7 +4,7 @@ use Sirum\Logging\SirumLog;
 
 function order_dispensed_event($order, $salesforce, $hours_to_wait) {
 
-  if ($order[0]['patient_active']) {
+  if (@$order[0]['patient_active']) {
     log_warning('order_dispensed_event canceled because patient inactive', get_defined_vars());
     return;
   }

--- a/updates/update_order_items.php
+++ b/updates/update_order_items.php
@@ -186,10 +186,11 @@ function update_order_items($changes) {
 
     //TODO Update Salesforce Order Total & Order Count & Order Invoice using REST API or a MYSQL Zapier Integration
   }
+  log_timer('order-items-updated', $loop_timer, $count_updated);
 
   SirumLog::resetSubroutineId();
 }
-log_timer('order-items-updated', $loop_timer, $count_updated);
+
 
 
 function deduplicate_order_items($item, $mssql, $mysql) {


### PR DESCRIPTION
* Don't create notice if $args isn't an array for the log
* Squelch the variables in the key for the timer name
* Squelch the patient_active check
* the log_timer was in the wrong position.  It was outside the function instead of outside the loop