### PR TITLE
rx_number will not exist if rx is not in the order

### DIFF
--- a/helpers/helper_full_item.php
+++ b/helpers/helper_full_item.php
@@ -37,7 +37,8 @@ function load_full_item($partial, $mysql, $overwrite_rx_messages = false) {
 
     foreach ($full_order as $full_item) {
 
-        if ($full_item['rx_number'] != $item['rx_number']) {
+        //$item might not have rx_number if not in order so need to use $partial
+        if ($full_item['rx_number'] != $partial['rx_number']) {
             continue;
         }
 


### PR DESCRIPTION
this was causing the alert "load_full_item: order found but no matching item!" which returned an empty item, which in turn was making order_updated_notices not send for drug removals