### PR TITLE
Fix single message deletion from Queue

### DIFF
--- a/classes/GoodPill/AWS/SQS/Queue.php
+++ b/classes/GoodPill/AWS/SQS/Queue.php
@@ -143,10 +143,11 @@ class Queue
      * @return null
      */
     public function delete(Request $request) {
+        $message = $request->toSQSDelete();
         return $this->sqs_client->deleteMessage(
             [
-                'QueueUrl' 	    => $this->queue_url,
-                'ReceiptHandle' => $request->receipt_handle
+                'QueueUrl'      => $this->queue_url,
+                'ReceiptHandle' => $message["ReceiptHandle"]
             ]
         );
     }


### PR DESCRIPTION
Found a small issue while writing some scaffolding and test code. The `$request` object sets the receipt handle as a protected property and it can't be accessed. There was however another transformer method in the request object that transforms it into useable data