### PR TITLE
Skip Pager Duty alert for common order delete reasons

### DIFF
--- a/updates/update_orders_wc.php
+++ b/updates/update_orders_wc.php
@@ -269,15 +269,18 @@ function wc_order_deleted(array $deleted) : bool
         $deleted
     );
 
-    $isRecentFill = false;
+    $skipPagerDutyAlert = false;
 
     foreach($order as $item) {
-        if ($item['rx_message_key'] === "NO ACTION RECENT FILL") {
-            $isRecentFill = true;
+        if (
+            $item['rx_message_key'] === "NO ACTION RECENT FILL" ||
+            $item['rx_message_key'] === "ACTION PATIENT OFF AUTOFILL"
+        ) {
+            $skipPagerDutyAlert = true;
         }
     }
 
-    if ($order[0]['order_status'] !== "Surescripts Authorization Denied" || !$isRecentFill) {
+    if ($order[0]['order_status'] !== "Surescripts Authorization Denied" || !$skipPagerDutyAlert) {
         GPLog::critical(
             "Order deleted from WC. Why?",
             [

--- a/updates/update_orders_wc.php
+++ b/updates/update_orders_wc.php
@@ -277,6 +277,7 @@ function wc_order_deleted(array $deleted) : bool
             $item['rx_message_key'] === "ACTION PATIENT OFF AUTOFILL"
         ) {
             $skipPagerDutyAlert = true;
+            break;
         }
     }
 

--- a/updates/update_orders_wc.php
+++ b/updates/update_orders_wc.php
@@ -269,16 +269,27 @@ function wc_order_deleted(array $deleted) : bool
         $deleted
     );
 
-    GPLog::critical(
-        "Order deleted from WC. Why?",
-        [
-            'source'  => 'WooCommerce',
-            'event'   => 'deleted',
-            'type'    => 'orders',
-            'deleted' => $deleted,
-            'order'   => $order
-        ]
-    );
+    $isRecentFill = false;
+
+    foreach($order as $item) {
+        if ($item['rx_message_key'] === "NO ACTION RECENT FILL") {
+            $isRecentFill = true;
+        }
+    }
+
+    if ($order[0]['order_status'] !== "Surescripts Authorization Denied" || !$isRecentFill) {
+        GPLog::critical(
+            "Order deleted from WC. Why?",
+            [
+                'source'  => 'WooCommerce',
+                'event'   => 'deleted',
+                'type'    => 'orders',
+                'deleted' => $deleted,
+                'order'   => $order
+            ]
+        );
+    }
+
 
     //NOTE the below will fail if the order is wc-cancelled.  because it will show up as deleted here
     //but if it was improperly cancelled and the cp order still exists then export_wc_create_order()


### PR DESCRIPTION
- Checks to see if the first order item status is denied
- Checks to see if any order item has an rx key of "NO ACTION RECENT FILL". When looking through the full order, some items had different keys.