### PR TITLE
Log Orders that are shipped but not dispensed

### DIFF
--- a/helpers/helper_full_order.php
+++ b/helpers/helper_full_order.php
@@ -285,6 +285,7 @@ function get_current_orders($mysql, $conditions = []) {
     WHERE
       $where
       order_date_dispensed IS NULL
+    AND order_date_shipped IS NULL
     ORDER BY
       invoice_number ASC
   ";


### PR DESCRIPTION
- Add critical log and check for orders shipped but not dispensed
- Add check for date shipped null to properly find duplicate orders