### PR TITLE
Dont transfer manual items

### DIFF
--- a/helpers/helper_days_and_message.php
+++ b/helpers/helper_days_and_message.php
@@ -19,6 +19,13 @@ use GoodPill\Logging\{
  */
 function get_days_and_message($item, $patient_or_order)
 {
+    GPLog::debug(
+        "Get Days And Message Input Parameters",
+        [
+            'item' => $item,
+            'patient_or_order'  => $patient_or_order,
+        ]
+    );
 
   // Is this an item we will transfer
     $no_transfer      = is_no_transfer($item);
@@ -154,7 +161,8 @@ function get_days_and_message($item, $patient_or_order)
         return [0, RX_MESSAGE['ACTION CHECK BACK']];
     }
 
-    if (! $no_transfer and ! $is_refill and $refill_only) {
+    // Don't return this if the item was manually added
+    if (! $no_transfer and ! $is_refill and $refill_only and ! $added_manually) {
         GPLog::info("TRANSFER OUT NEW RXS THAT WE CANT FILL", get_defined_vars());
         return [0, RX_MESSAGE['NO ACTION WILL TRANSFER CHECK BACK']];
     }

--- a/updates/update_orders_cp.php
+++ b/updates/update_orders_cp.php
@@ -250,6 +250,9 @@ function cp_order_created(array $created) : ?array
         // Care point will still attach an order item when it is surescript Denied
         // This results in a negative number since we are removing an item
         // but sure script sends an item_count of 0
+
+        //  In a case where authorization was approved, an item was found to be duplicated in other orders
+        //  The duplicates were removed but the count was higher that the count items being filled from the original order
         if (
             (
                 $order[0]['order_status'] == "Surescripts Authorization Denied"
@@ -257,7 +260,7 @@ function cp_order_created(array $created) : ?array
             )
             || (
                 $order[0]['order_status'] != "Surescripts Authorization Denied"
-                && $order[0]['count_items'] - $order[0]['count_to_remove'] - $order[0]['count_duplicates_removed']!= 0
+                && $order[0]['count_items'] - $order[0]['count_to_remove'] - $order[0]['count_duplicates_removed'] > 0
             )
         ) {
             // Find the item that wasn't removed, but we aren't filling


### PR DESCRIPTION
- Adds check to see if item was manually added before transferring out
- Adds a debug log to see the full item and order being passed in to days_and_message helper
- Adds a check to see if count_filled - remove - duplicates is only greater than 0. Found condition where there were more duplicates removed than items to fill.