### PR TITLE
Force Payment update if rxs added to order

### DIFF
--- a/helpers/helper_full_fields.php
+++ b/helpers/helper_full_fields.php
@@ -136,26 +136,27 @@ function add_full_fields($patient_or_order, $mysql, $overwrite_rx_messages)
             $needs_repending = (@$patient_or_order[$i]['item_date_added'] AND $days_changed AND ! $needs_pending);
 
             $get_days_and_message = [
-              "overwrite_rx_messages"      => $overwrite_rx_messages,
-              'is_order'                   => $is_order,
-              'is_new_order'               => $is_new_order,
-              "rx_number"                  => $patient_or_order[$i]['rx_number'],
-              "item_added"                 => @$patient_or_order[$i]['item_date_added'].' '.@$patient_or_order[$i]['item_added_by'],
+                "overwrite_rx_messages" => $overwrite_rx_messages,
+                'is_order'              => $is_order,
+                'is_new_order'          => $is_new_order,
+                "rx_number"             => $patient_or_order[$i]['rx_number'],
+                "item_added"            => @$patient_or_order[$i]['item_date_added'] . ' ' . @$patient_or_order[$i]['item_added_by'],
 
-              "new_days_dispensed_default" => $days,
-              "old_days_dispensed_default" => @$patient_or_order[$i]['days_dispensed_default'], //Applicable for order but not for patient
+                "new_days_dispensed_default" => $days,
+                "old_days_dispensed_default" => @$patient_or_order[$i]['days_dispensed_default'], //Applicable for order but not for patient
 
-              "new_rx_message_text"        => "$message[EN] ($message[CP_CODE])",
-              "old_rx_message_text"        => $patient_or_order[$i]['rx_message_text'],
+                "new_rx_message_text" => "$message[EN] ($message[CP_CODE])",
+                "old_rx_message_text" => $patient_or_order[$i]['rx_message_text'],
 
-              "item"                       => $patient_or_order[$i],
-              'needs_adding'               => $needs_adding,
-              'needs_removing'             => $needs_removing,
-              "needs_pending"              => $needs_pending,
-              "needs_unpending"            => $needs_unpending,
-              "needs_repending"            => $needs_repending,
-              "days_changed"               => $days_changed,
-              "sync_to_date_days_before"   => @$patient_or_order[$i]['sync_to_date_days_before']
+                "item"                     => $patient_or_order[$i],
+                'needs_adding'             => $needs_adding,
+                'needs_removing'           => $needs_removing,
+                "needs_pending"            => $needs_pending,
+                "needs_unpending"          => $needs_unpending,
+                "needs_repending"          => $needs_repending,
+                "days_added"               => $days_added,
+                "days_changed"             => $days_changed,
+                "sync_to_date_days_before" => @$patient_or_order[$i]['sync_to_date_days_before']
             ];
 
              //54376 Sertraline. Probably should create a new order?

--- a/updates/update_rxs_single.php
+++ b/updates/update_rxs_single.php
@@ -478,6 +478,25 @@ function update_rxs_single($changes)
                     [$created['drug_name']]
                 );
             }
+
+            //  Check to see if newly created item already has item_date_added
+            //  If it's already set, update payment
+
+            if ($item && $item['item_date_added'] && $item['invoice_number']) {
+                $reason = "rxs-single-created2: Item created with date_added {$item['drug_name']}";
+                $order = get_full_order($mysql, $item['invoice_number']);
+
+                GPLog::debug(
+                    $reason,
+                    [
+                        'invoice_number'  => $item['invoice_number'],
+                        'item'    => $item,
+                        'order'    => $order
+                    ]
+                );
+
+                helper_update_payment($order, $reason, $mysql);
+            }
         }
     }
     /* Finish Created Loop #2 */


### PR DESCRIPTION
```
Our current hypothesis is.  The rx_created and order_item_created came in at the same time.
The second half of the rx_created does a load_full_fields.  this loaded the item and pended it but since there was a date_added already it didn't trigger the price helper.
I think the short term solution is to add a check to that bottom loop that says if rx_create and has a date_added we recalculate price
```

Adding check to update_rxs_single to check if rx is created at same time the order is updated. Should catch situations where the rx created and the order item are created in the same execution. Since these events execute out of sync the regular payment helpers are executed on the order, so this should force the payment recalculation.