### PR TITLE
Refactor findGroupId

### DIFF
--- a/classes/GoodPill/Models/GpPatient.php
+++ b/classes/GoodPill/Models/GpPatient.php
@@ -9,6 +9,7 @@ namespace Goodpill\Models;
 use Carbon\Carbon;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Support\Facades\DB;
+use GoodPill\Models\GpOrder;
 
 /**
  * Class GpPatient
@@ -74,7 +75,7 @@ class GpPatient extends Model
 		'patient_id_cp' => 'int',
 		'patient_id_wc' => 'int',
 		'patient_autofill' => 'int',
-		'refills_used' => 'float'
+		'refills_used' => 'float',
 	];
 
 	protected $dates = [
@@ -144,5 +145,15 @@ class GpPatient extends Model
         return ($this->exists
                 && !empty($this->patient_id_cp)
                 && !empty($this->patient_id_wc));
+    }
+
+    public function orders() {
+        return $this
+            ->hasMany(GpOrder::class, 'patient_id_cp')
+            ->orderBy('invoice_number', 'desc');
+    }
+
+    public function getBirthDateAttribute($val) {
+        return $val;
     }
 }

--- a/classes/GoodPill/Models/GpPatient.php
+++ b/classes/GoodPill/Models/GpPatient.php
@@ -153,7 +153,8 @@ class GpPatient extends Model
             ->orderBy('invoice_number', 'desc');
     }
 
-    public function getBirthDateAttribute($val) {
-        return $val;
+    public function getBirthDateFormattedAttribute() {
+        return $this->birth_date->format('Y-m-d');
     }
 }
+

--- a/classes/GoodPill/Models/GpPatient.php
+++ b/classes/GoodPill/Models/GpPatient.php
@@ -79,7 +79,6 @@ class GpPatient extends Model
 	];
 
 	protected $dates = [
-		'birth_date',
 		'payment_card_date_expired',
 		'patient_date_added',
 		'patient_date_registered',
@@ -151,10 +150,6 @@ class GpPatient extends Model
         return $this
             ->hasMany(GpOrder::class, 'patient_id_cp')
             ->orderBy('invoice_number', 'desc');
-    }
-
-    public function getBirthDateFormattedAttribute() {
-        return $this->birth_date->format('Y-m-d');
     }
 }
 

--- a/helpers/helper_sqs.php
+++ b/helpers/helper_sqs.php
@@ -142,7 +142,7 @@ function findGroupId(array $data): string {
         $patient = $order->patient;
     }
     if ($patient) {
-        return $patient->first_name.'_'.$patient->last_name.'_'.$patient->birth_date_formatted;
+        return $patient->first_name.'_'.$patient->last_name.'_'.$patient->birth_date;
     } else {
         return 'UNKNOWN_GROUP_ID';
     }

--- a/helpers/helper_sqs.php
+++ b/helpers/helper_sqs.php
@@ -55,27 +55,17 @@ function get_sync_request_single(
         case 'orders_cp':
         case 'orders_wc':
         case 'order_items':
-            if (isset($changes['patient_id_cp'])) {
-                $patient = GpPatient::where('patient_id_cp', '=', $changes['patient_id_cp'])->first();
-            } elseif (isset($changes['patient_id_wc'])) {
-                $patient = GpPatient::where('patient_id_wc', '=', $changes['patient_id_wc'])->first();
-            } elseif (isset($changes['invoice_number'])) {
-                $order = GpOrder::where('invoice_number', '=', $changes['invoice_number'])->first();
-                $patient = $order->getPatient();
-            }
+            $group_id = findGroupId($changes);
 
-            if ($patient && $patient->exists) {
-                $group_id = $patient->first_name.'_'.$patient->last_name.'_'.$patient->birth_date;
-            } else {
+            if ($group_id === 'UNKNOWN_GROUP_ID') {
                 GPLog::warning(
                     "Problem finding a patient group id",
                     [
                         'changes' => $changes,
                         'changes_to' => $changes_to,
                         'change_type' => $change_type,
-                     ]
+                    ]
                 );
-                $group_id = 'UNKNOWN_GROUP_ID';
             }
             break;
         default:
@@ -100,4 +90,61 @@ function get_sync_request_single(
     $syncing_request->patient_id   = $group_id;
     $syncing_request->execution_id = $execution;
     return $syncing_request;
+}
+
+/**
+ * Create a pharmacy sync request for an rxs_single change.
+ * @param $patient_id_cp
+ * @param string $changes_to
+ * @param array $changes
+ * @param string|null $execution
+ * @return PharmacySyncRequest|null
+ */
+function get_sync_request_rxs(
+    $patient_id_cp,
+    string $changes_to,
+    array $changes,
+    string $execution = null
+) : ?PharmacySyncRequest
+{
+    $group_id = find_group_id(['patient_id_cp' => $$patient_id_cp]);
+
+    $syncing_request               = new PharmacySyncRequest();
+    $syncing_request->changes_to   = $changes_to;
+    $syncing_request->changes      = $changes;
+    $syncing_request->group_id     = sha1($group_id);
+    $syncing_request->patient_id   = $group_id;
+    $syncing_request->execution_id = $execution;
+
+    return $syncing_request;
+}
+
+/**
+ * Helper to quickly find patient by id or invoice and create a group id
+ * @param array $data
+ * @return string
+ */
+function findGroupId(array $data): string {
+    [
+        'patient_id_cp'  => $patient_id_cp,
+        'patient_id_wc'  => $patient_id_wc,
+        'invoice_number' => $invoice_number,
+    ] = $data;
+
+    if ($patient_id_cp) {
+        $patient = GpPatient::find($patient_id_cp)
+            ->first(['first_name', 'last_name', 'birth_date']);
+    } elseif ($patient_id_wc) {
+        $patient = GpPatient::where('patient_id_wc', $patient_id_wc)
+            ->first(['first_name', 'last_name', 'birth_date']);
+    } elseif ($invoice_number) {
+        $patient = GpOrder::find($data['invoice_number'])->patient;
+    }
+
+    if ($patient) {
+        $group_id = $patient->first_name.'_'.$patient->last_name.'_'.$patient->birth_date;
+        return $group_id;
+    } else {
+        return 'UNKNOWN_GROUP_ID';
+    }
 }

--- a/helpers/helper_sqs.php
+++ b/helpers/helper_sqs.php
@@ -138,12 +138,11 @@ function findGroupId(array $data): string {
         $patient = GpPatient::where('patient_id_wc', $patient_id_wc)
             ->first(['first_name', 'last_name', 'birth_date']);
     } elseif ($invoice_number) {
-        $patient = GpOrder::find($data['invoice_number'])->patient;
+        $order = GpOrder::with('patient:patient_id_cp,first_name,last_name,birth_date')->find($data['invoice_number'], ['patient_id_cp']);
+        $patient = $order->patient;
     }
-
     if ($patient) {
-        $group_id = $patient->first_name.'_'.$patient->last_name.'_'.$patient->birth_date;
-        return $group_id;
+        return $patient->first_name.'_'.$patient->last_name.'_'.$patient->birth_date_formatted;
     } else {
         return 'UNKNOWN_GROUP_ID';
     }


### PR DESCRIPTION
- updated relationships between orders and patients
- Scoped `birth_date` to fetch what is retrieved from the database. It is currently returning a datetime of the field containing the time portion. If the field were removed from the `$dates` cast the getter could be removed
- Added a new `findGroupId` helper that uses the models. Also added the `get_sync_request_rxs` helper back in to eventually replace the logic for `rxs_single` in the sync_requests file.