### PR TITLE
Trying to solve issues for stray data that gets left from multiple us…

### DIFF
--- a/updates/update_patients_wc.php
+++ b/updates/update_patients_wc.php
@@ -150,7 +150,7 @@ function wc_patient_created(array $created)
     $is_match = is_patient_match($created);
 
     if ($is_match) {
-        match_patient($mysql, $is_match['patient_id_cp'], $is_match['patient_id_wc']);
+        match_patient($is_match['patient_id_cp'], $is_match['patient_id_wc']);
     }
 
     GPLog::resetSubroutineId();
@@ -205,10 +205,17 @@ function wc_patient_updated(array $updated)
     }
 
     if (! $updated['patient_id_cp']) {
+        // See if this user is already matched to a patien
         $is_match = is_patient_match($updated);
 
+        // we are passing !$is_match['new'] because we want to force
+        // the match if they are matched in the gp_tables
         if ($is_match) {
-            match_patient($mysql, $is_match['patient_id_cp'], $is_match['patient_id_wc']);
+            match_patient(
+                $is_match['patient_id_cp'],
+                $is_match['patient_id_wc'],
+                !$is_match['new']
+            );
         }
 
         return null;


### PR DESCRIPTION
…er registrations.

* Update is_patient_match so it return (bool) $new.  This will be set to false if the patient is matched i gp_patients already.  It will be set to true if the match came from logic to process carepoint and woocommerce matches based on names.
* Update match_patient to take a thrid parameter that forces the match to happen.  This parameter will delete any wc meta for that id_cp and then update with new met to match the patient.  We will want to do this when the is_patient_match is false.  Assuming that if the patient is matched in the gp table, that is law and should override other matches.
* remove the passing of $mysql since it isn't necessary anymore