### PR TITLE
Check Carepoint of count of items

### DIFF
--- a/updates/update_orders_cp.php
+++ b/updates/update_orders_cp.php
@@ -271,17 +271,19 @@ function cp_order_created(array $created) : ?array
             $order_to_find = $order[0]['invoice_number'];
             $mssql = new Mssql_Cp();
             $mssql_results = $mssql->run("
-                select c.rx_id, c.add_date, c.chg_date, rx.drug_name, rx.sig_code, rx.sig_text
+                select o.liCount as item_count, c.rx_id, c.add_date, c.chg_date, rx.drug_name, rx.sig_code, rx.sig_text
                 from csomline c
                 join cprx rx on rx.rx_id = c.rx_id
-                WHERE order_id = '$order_to_find'"
+                join csom o on o.order_id = c.order_id
+                WHERE c.order_id = '$order_to_find'"
             );
 
             GPLog::critical(
                 "update_orders_cp: created. canceling order, but is their a manually added item that we should keep?",
                 [
                     'invoice_number'           => $order[0]['invoice_number'],
-                    'count_in_cp'              => count(@$mssql_results[0]),
+                    'count_items_cp'           => count(@$mssql_results[0]),
+                    'count_on_order_cp'        => @$mssql_results[0][0]['item_count'],
                     'items_in_cp'              => @$mssql_results[0],
                     'count_filled'             => $order[0]['count_filled'],
                     'count_items'              => $order[0]['count_items'],

--- a/updates/update_orders_cp.php
+++ b/updates/update_orders_cp.php
@@ -266,10 +266,17 @@ function cp_order_created(array $created) : ?array
             // Find the item that wasn't removed, but we aren't filling
             // These values are transient and
             // TODO Why is this happening
+
+            //  Check Carepoint directly to see how many items are in the order
+            $order_to_find = $order[0]['invoice_number'];
+            $mssql = new Mssql_Cp();
+            $mssql_results = $mssql->run("select COUNT(*) as count_items FROM csomline WHERE order_id = '{$order_to_find}'");
+
             GPLog::critical(
                 "update_orders_cp: created. canceling order, but is their a manually added item that we should keep?",
                 [
                     'invoice_number'           => $order[0]['invoice_number'],
+                    'count_in_cp'              => @$mssql_results[0][0]['count_items'],
                     'count_filled'             => $order[0]['count_filled'],
                     'count_items'              => $order[0]['count_items'],
                     'count_to_add'             => $order[0]['count_to_add'],

--- a/updates/update_orders_cp.php
+++ b/updates/update_orders_cp.php
@@ -270,13 +270,19 @@ function cp_order_created(array $created) : ?array
             //  Check Carepoint directly to see how many items are in the order
             $order_to_find = $order[0]['invoice_number'];
             $mssql = new Mssql_Cp();
-            $mssql_results = $mssql->run("select COUNT(*) as count_items FROM csomline WHERE order_id = '{$order_to_find}'");
+            $mssql_results = $mssql->run("
+                select c.rx_id, c.add_date, c.chg_date, rx.drug_name, rx.sig_code, rx.sig_text
+                from csomline c
+                join cprx rx on rx.rx_id = c.rx_id
+                WHERE order_id = '$order_to_find'"
+            );
 
             GPLog::critical(
                 "update_orders_cp: created. canceling order, but is their a manually added item that we should keep?",
                 [
                     'invoice_number'           => $order[0]['invoice_number'],
-                    'count_in_cp'              => @$mssql_results[0][0]['count_items'],
+                    'count_in_cp'              => count(@$mssql_results[0]),
+                    'items_in_cp'              => @$mssql_results[0],
                     'count_filled'             => $order[0]['count_filled'],
                     'count_items'              => $order[0]['count_items'],
                     'count_to_add'             => $order[0]['count_to_add'],


### PR DESCRIPTION
Check carepoint and get a count of items. For debugging purposes to see if that count is consistent with `count_items`. If it isn't we could use that value to make a smarter determination about whether to throw this error in the future, or go back through the code to figure out why the count is inconsistent