### PR TITLE
Update check_order_status cron with additional log

### DIFF
--- a/cronjobs/check_order_status.php
+++ b/cronjobs/check_order_status.php
@@ -51,6 +51,7 @@ if ($shipped_orders->count() > 0) {
 
     $message_as_string = implode('_', $salesforce);
     $notification = new \GoodPill\Notifications\Salesforce(sha1($message_as_string), $message_as_string);
+    echo sprintf("%s - Send debug message for shipped orders", date('Y-m-d h:i:s'));
 
     if (!$notification->isSent()) {
         GPLog::debug($shipped_subject, ['body' => $shipped_body]);
@@ -79,7 +80,7 @@ if ($dispensed_orders->count() > 0) {
 
     $message_as_string = implode('_', $salesforce);
     $notification = new \GoodPill\Notifications\Salesforce(sha1($message_as_string), $message_as_string);
-
+    echo sprintf("%s - Send debug message for dispensed orders", date('Y-m-d h:i:s'));
     if (!$notification->isSent()) {
         GPLog::debug($dispensed_subject, ['body' => $dispensed_body]);
 

--- a/cronjobs/check_order_status.php
+++ b/cronjobs/check_order_status.php
@@ -51,9 +51,8 @@ if ($shipped_orders->count() > 0) {
 
     $message_as_string = implode('_', $salesforce);
     $notification = new \GoodPill\Notifications\Salesforce(sha1($message_as_string), $message_as_string);
-    CliLog::notice("Send debug message for shipped order");
+    CliLog::notice("Send notification for shipped orders waiting tracking number");
 
-    echo sprintf("%s - Send debug message for shipped orders", date('Y-m-d h:i:s'));
 
     if (!$notification->isSent()) {
         GPLog::debug($shipped_subject, ['body' => $shipped_body]);
@@ -82,7 +81,8 @@ if ($dispensed_orders->count() > 0) {
 
     $message_as_string = implode('_', $salesforce);
     $notification = new \GoodPill\Notifications\Salesforce(sha1($message_as_string), $message_as_string);
-    echo sprintf("%s - Send debug message for dispensed orders", date('Y-m-d h:i:s'));
+    CliLog::notice("Send notification for dispensed orders waiting shipment");
+
     if (!$notification->isSent()) {
         GPLog::debug($dispensed_subject, ['body' => $dispensed_body]);
 
@@ -93,4 +93,4 @@ if ($dispensed_orders->count() > 0) {
 
     $notification->increment();
 }
-echo "Finished check_order_status cron";
+CliLog::notice("Finished check_order_status cron");


### PR DESCRIPTION
Checked printed statements to see how many orders were dispensed or shipped. There should have been at least 2 logs and 2 salesforce notifications going out. I'm adding timestamps right before sending out a log message to see what time the cron is actually running and further debug why no notifications are going out.