### PR TITLE
Bb/add exec and subroutine id to all sqs messages

### DIFF
--- a/async_jobs/gdoc_requests.php
+++ b/async_jobs/gdoc_requests.php
@@ -68,6 +68,10 @@ for ($l = 0; $l < $executions; $l++) {
                 GPLog::$exec_id = $request->execution_id;
             }
 
+            if (isset($request->subroutine_id)) {
+                GPLog::$subroutine_id = $request->subroutine_id;
+            }
+
             // Figure out the type of message
             if ($request instanceof HelperRequest) {
                 $url = GD_HELPER_URL;

--- a/async_jobs/gdoc_requests.php
+++ b/async_jobs/gdoc_requests.php
@@ -64,6 +64,10 @@ for ($l = 0; $l < $executions; $l++) {
                 $request->fileId
             );
 
+            if (isset($request->execution_id)) {
+                GPLog::$exec_id = $request->execution_id;
+            }
+
             // Figure out the type of message
             if ($request instanceof HelperRequest) {
                 $url = GD_HELPER_URL;

--- a/async_jobs/patient_requests.php
+++ b/async_jobs/patient_requests.php
@@ -169,6 +169,10 @@ for ($l = 0; $l < $executions; $l++) {
                 GPLog::$exec_id = $request->execution_id;
             }
 
+            if (isset($request->subroutine_id)) {
+                GPLog::$subroutine_id = $request->subroutine_id;
+            }
+
             GPLog::debug($log_message, $changes);
             CliLog::notice($log_message, $changes);
 

--- a/async_jobs/sync_requests.php
+++ b/async_jobs/sync_requests.php
@@ -171,6 +171,10 @@ for ($l = 0; $l < $executions; $l++) {
                 GPLog::$exec_id = $request->execution_id;
             }
 
+            if (isset($request->subroutine_id)) {
+                GPLog::$subroutine_id = $request->subroutine_id;
+            }
+
             GPLog::notice(
                 $log_message,
                 ['changes_to' => $request->changes_to, 'change' => $changes]
@@ -184,7 +188,7 @@ for ($l = 0; $l < $executions; $l++) {
                     case 'stock_by_month':
                         update_stock_by_month($changes);
                         break;
-                        
+
                     case 'order_items':
                     case 'rxs_single':
                         // This is an expensive operation, So instead of breaking it into one per

--- a/async_jobs/sync_requests.php
+++ b/async_jobs/sync_requests.php
@@ -184,11 +184,11 @@ for ($l = 0; $l < $executions; $l++) {
                     case 'stock_by_month':
                         update_stock_by_month($changes);
                         break;
-
+                        
+                    case 'order_items':
                     case 'rxs_single':
                         // This is an expensive operation, So instead of breaking it into one per
                         // rx, we are going to split all the users
-
 
                         // Order them by patient_id_cp
                         $grouped_changes = [];
@@ -229,7 +229,6 @@ for ($l = 0; $l < $executions; $l++) {
                     case 'patients_wc':
                     case 'orders_cp':
                     case 'orders_wc':
-                    case 'order_items':
                         foreach (array_keys($request->changes) as $change_type) {
                             foreach($request->changes[$change_type] as $changes) {
                                 $new_request = get_sync_request_single($request->changes_to, $change_type, $changes, $request->execution_id);

--- a/classes/GoodPill/AWS/SQS/PharmacySyncRequest.php
+++ b/classes/GoodPill/AWS/SQS/PharmacySyncRequest.php
@@ -12,7 +12,6 @@ class PharmacySyncRequest extends Request
     protected $properties = [
         'changes_to',
         'changes',
-        'execution_id',
         'patient_id'
     ];
 

--- a/classes/GoodPill/AWS/SQS/Request.php
+++ b/classes/GoodPill/AWS/SQS/Request.php
@@ -2,6 +2,8 @@
 
 namespace  GoodPill\AWS\SQS;
 
+use GoodPill\Logging\GPLog;
+
 abstract class Request
 {
 
@@ -59,9 +61,15 @@ abstract class Request
     /**
      * Don't check the properties for validity.  Set this to false for an easy
      * way to force a message creation
+     *
+     * @var boolean
      */
     public $check_property = true;
 
+    /**
+     * Allow duplicate occurances of this mesage to be sent to the Queue
+     * @var boolean
+     */
     public $allow_duplicate = false;
 
     /**
@@ -69,6 +77,20 @@ abstract class Request
      */
     public function __construct($initialize_date = null)
     {
+
+        if (!in_array('execution_id', $this->properties)) {
+            $this->properties[] = 'execution_id';
+            $this->execution_id = GPLog::$exec_id;
+        }
+
+        if (!in_array('subroutine_id', $this->properties)) {
+            $this->properties[] = 'subroutine_id';
+            if (!is_null(GPLog::$subroutine_id)) {
+                $this->subroutine_id = GPLog::$subroutine_id;
+            }
+        }
+
+
         $this->dedup_id = uniqid();
 
         if (is_array($initialize_date)) {

--- a/cronjobs/syncing.php
+++ b/cronjobs/syncing.php
@@ -413,17 +413,12 @@ try {
         }
 
 
-        // Orders WC
-        if ($has_changes = get_sync_request('order_items', ['created'], $changes_to_order_items, $exec_id)) {
+        // We need to group the created and deleted items into a single execution so we can combine
+        // The messaging in the next step
+        if ($has_changes = get_sync_request('order_items', ['created', 'deleted'], $changes_to_order_items, $exec_id)) {
             $changes_sqs_messages[] = $has_changes;
         } else {
             CliLog::notice('Nothing to Queue order_items.created');
-        }
-
-        if ($has_changes = get_sync_request('order_items', ['deleted'], $changes_to_order_items, $exec_id)) {
-            $changes_sqs_messages[] = $has_changes;
-        } else {
-            CliLog::notice('Nothing to Queue order_items.deleted');
         }
 
         if ($has_changes = get_sync_request('order_items', ['updated'], $changes_to_order_items, $exec_id)) {


### PR DESCRIPTION
We need to make sure all SQS messages have the execution_id and subroutine_id.  