### PR TITLE
Update WC Order Payments with fee instead of due

### DIFF
--- a/exports/export_wc_orders.php
+++ b/exports/export_wc_orders.php
@@ -412,7 +412,12 @@ function export_wc_create_order($order, $reason)
     export_wc_update_order_status($order);
     export_wc_update_order_metadata($order, 'wc_insert_meta');
     export_wc_update_order_address($order, 'wc_insert_meta');
-    $due_to_send = $first_item['order_source'] == 'Auto Refill v2' ? $first_item['payment_fee_default'] : $first_item['payment_due_default'];
+
+    $due_to_send = (
+        $first_item['order_source'] == 'Auto Refill v2' ||
+        $first_item['payment_coupon'] ||
+        $first_item['payment_method'] == PAYMENT_METHOD['AUTOPAY']
+    ) ? $first_item['payment_fee_default'] : $first_item['payment_due_default'];
 
     export_wc_update_order_payment(
         $invoice_number,
@@ -486,7 +491,12 @@ function export_wc_update_order($order)
     export_wc_update_order_status($order);
     export_wc_update_order_metadata($order);
     export_wc_update_order_address($order);
-    $due_to_send = $order[0]['order_source'] == 'Auto Refill v2' ? $order[0]['payment_fee_default'] : $order[0]['payment_due_default'];
+
+    $due_to_send = (
+        $order[0]['order_source'] == 'Auto Refill v2' ||
+        $order[0]['payment_coupon'] ||
+        $order[0]['payment_method'] == PAYMENT_METHOD['AUTOPAY']
+    ) ? $order[0]['payment_fee_default'] : $order[0]['payment_due_default'];
     export_wc_update_order_payment(
         $order[0]['invoice_number'],
         $order[0]['payment_fee_default'],
@@ -609,7 +619,7 @@ function export_wc_update_order_payment($invoice_number, $payment_fee, $payment_
                 "invoice"     => $invoice_number,
                 "payment_fee" => $payment_fee,
                 "payment_due" => $payment_due,
-                "url"         => $url,
+                "url"         => $urlToFetch,
                 "response"    => $response
             ]
         );
@@ -624,7 +634,7 @@ function export_wc_update_order_payment($invoice_number, $payment_fee, $payment_
                 "invoice"     => $invoice_number,
                 "payment_fee" => $payment_fee,
                 "payment_due" => $payment_due,
-                "url"         => $url,
+                "url"         => $urlToFetch,
                 "response"    => $response
             ]
         );

--- a/helpers/helper_payment.php
+++ b/helpers/helper_payment.php
@@ -40,8 +40,17 @@ function helper_update_payment($order, $reason, $mysql)
             ]
         );
         set_payment_default($order, $mysql);
-        //  Should this also be set to use the total instead of payment_due_default ?
-        export_wc_update_order_payment($order[0]['invoice_number'], $order[0]['payment_fee_default'], $order[0]['payment_due_default']);
+        $due_to_send = (
+            $order[0]['order_source'] == 'Auto Refill v2' ||
+            $order[0]['payment_coupon'] ||
+            $order[0]['payment_method'] == PAYMENT_METHOD['AUTOPAY']
+        ) ? $order[0]['payment_fee_default'] : $order[0]['payment_due_default'];
+
+        export_wc_update_order_payment(
+            $order[0]['invoice_number'],
+            $order[0]['payment_fee_default'],
+            $due_to_send
+        );
         return $order;
     }
 

--- a/helpers/helper_payment.php
+++ b/helpers/helper_payment.php
@@ -40,6 +40,7 @@ function helper_update_payment($order, $reason, $mysql)
             ]
         );
         set_payment_default($order, $mysql);
+        //  Should this also be set to use the total instead of payment_due_default ?
         export_wc_update_order_payment($order[0]['invoice_number'], $order[0]['payment_fee_default'], $order[0]['payment_due_default']);
         return $order;
     }


### PR DESCRIPTION
Under certain conditions, the an invoice in wc should show the fee instead of payment_due. 

Checks to see if auto refill, paying with a coupon or has autopay on. If any of those are true then the WC order should be updated with the fee instead of due. In these situations where there is patient on autopay, they still have a total amount due, but autopay will clear the balance out so there is no action on their part.

In the case of a coupon, the same should be true where there is a total but the coupon will be applied. Need to confirm that we want to actually show the total to the patient in the patient portal before merging.