### PR TITLE
Insert csomline into csomline_deleted

### DIFF
--- a/exports/export_cp_order_items.php
+++ b/exports/export_cp_order_items.php
@@ -17,11 +17,11 @@ function export_cp_remove_items($invoice_number, $items = [])
 
     $order_id   = $invoice_number - 2; //TODO SUPER HACKY
     //  @todo - insert this current_datetime into the deleted table
-    //  @todo - determine which user_id to update with pharmacy user in deleted table. Is there a preference?
+    //  Omitting updating the `chg_date` field in the deleted table. Unsure if it will overwrite with the current timestamp
     //  $current_datetime = date('Y-m-d H:i:s');
     $sql_to_insert_deleted = "
-        INSERT into csomline_deleted (line_id, order_id, rx_id, rxdisp_id, line_state_cn, line_status_cn, hold_yn, add_user_id, add_date, chg_user_id, chg_date)
-        SELECT line_id, order_id, rx_id, rxdisp_id, line_state_cn, line_status_cn, hold_yn, add_user_id, add_date, chg_user_id, chg_date FROM csomline
+        INSERT into csomline_deleted (line_id, order_id, rx_id, rxdisp_id, line_state_cn, line_status_cn, hold_yn, add_user_id, add_date, chg_user_id)
+        SELECT line_id, order_id, rx_id, rxdisp_id, line_state_cn, line_status_cn, hold_yn, add_user_id, add_date, 1311 FROM csomline
         WHERE csomline.order_id = '{$order_id}'
         AND rxdisp_id = 0";
 


### PR DESCRIPTION
- Before an order item is deleted from csomline, move it into a new table to keep a record of each item that gets deleted
- Should update the `chg_user_id` field to use the new pharmacy automation user.
- This does not update the `chg_date` column when moving the item over. I think this is a datetime column that will add the current timestamp. I could be wrong though and it might make sense to just carry over the datetime from the `csomline` table