### PR TITLE
Remove Pager Duty Alert for unpending items, update Exports to use automation user

### DIFF
--- a/exports/export_cp_orders.php
+++ b/exports/export_cp_orders.php
@@ -10,11 +10,13 @@ use GoodPill\Logging\{
     CliLog
 };
 
+
 function export_cp_set_expected_by($item) {
 
   global $mssql;
+  $cp_automation_user = CAREPOINT_AUTOMATION_USER;
 
-  // this should happen if it does, throw an error and return.
+    // this should happen if it does, throw an error and return.
   if (empty($item['invoice_number'])) {
       GPLog::critical(
           'Trying to update CP Expected date, but missing invoice_nbr',
@@ -45,9 +47,9 @@ function export_cp_set_expected_by($item) {
         $expected_by .= substr($item['order_date_added'], -9); //timestamp with leading space
   }
 
-
   $sql = "UPDATE csom
-          SET expected_by = '{$expected_by}'
+          SET expected_by = '{$expected_by}',
+              chg_user_id = '{$cp_automation_user}'
           WHERE invoice_nbr = {$item['invoice_number']}";
 
   GPLog::notice(
@@ -67,8 +69,9 @@ function export_cp_remove_order($invoice_number, $reason) {
 
   global $mssql;
   $mssql = $mssql ?: new Mssql_Cp();
+  $cp_automation_user = CAREPOINT_AUTOMATION_USER;
 
-  GPLog::notice(
+    GPLog::notice(
     "export_cp_remove_order: Order deleting $invoice_number",
     [
       'invoice_number'  => $invoice_number,
@@ -81,7 +84,10 @@ function export_cp_remove_order($invoice_number, $reason) {
   if ( ! $new_count_items) { //if no items were dispensed yet, archive order
 
     $sql = "
-      UPDATE csom SET status_cn = 3 WHERE invoice_nbr = $invoice_number -- chg_user_id = @user_id, chg_date = @today
+      UPDATE csom 
+      SET status_cn = 3,
+          chg_user_id = '{$cp_automation_user}'
+      WHERE invoice_nbr = $invoice_number -- chg_user_id = @user_id, chg_date = @today
     ";
 
     $res = $mssql->run($sql);
@@ -115,9 +121,14 @@ function export_cp_remove_order($invoice_number, $reason) {
 }
 
 function export_cp_append_order_note($mssql, $invoice_number, $note) {
+    $cp_automation_user = CAREPOINT_AUTOMATION_USER;
 
     $sql = "
-      UPDATE csom SET comments = RIGHT(CONCAT(comments, CHAR(10), '$note'), 255) WHERE invoice_nbr = $invoice_number -- chg_user_id = @user_id, chg_date = @today
+      UPDATE csom 
+      SET comments = RIGHT(CONCAT(comments, CHAR(10), '$note'), 255)
+          chg_user_id = '{$cp_automation_user}'
+      
+      WHERE invoice_nbr = $invoice_number -- chg_user_id = @user_id, chg_date = @today
     ";
 
     $res = $mssql->run($sql);

--- a/exports/export_v2_order_items.php
+++ b/exports/export_v2_order_items.php
@@ -235,14 +235,6 @@ function v2_unpend_item($item, $mysql, $reason)
             ),
             $item
         );
-        GPLog::critical(
-            "v2_unpend_item: NO INVOICE NUMBER, ORDER DATE ADDED, OR PATIENT DATE ADDED! "
-                . @$item['invoice_number'] . " " . @$item['drug_name'] . " $reason "
-                . @$item['rx_number'] . ". rx_dispensed_id:" . @$item['rx_dispensed_id']
-                . " last_inventory:" . @$item['last_inventory'] . " count_pended_total:"
-                . @$item['count_pended_total'],
-            ['item' => $item]
-        );
     }
 
     unpend_pick_list($item);

--- a/helpers/helper_constants.php
+++ b/helpers/helper_constants.php
@@ -24,6 +24,7 @@ const ADDED_MANUALLY = [
   "WEBFORM"
 ];
 
+const CAREPOINT_AUTOMATION_USER = 1311;
 const PAYMENT_TOTAL_NEW_PATIENT = 6;
 
 const PICK_LIST_FOLDER_NAME         = 'Pick Lists';


### PR DESCRIPTION
- Removed the Pager Duty alert. It doesn't seem that the alert is useful, items are still unpending correctly.
- Updated a few queries to update with the chg_user_id of the automation user. I may have gone about this a bit weird where I created a constant for the user id, and then created a variable in each function. I couldn't figure out how use the constant directly in the query because of a type error