### PR TITLE
Add missing comma to exports query

### DIFF
--- a/exports/export_cp_orders.php
+++ b/exports/export_cp_orders.php
@@ -125,7 +125,7 @@ function export_cp_append_order_note($mssql, $invoice_number, $note) {
 
     $sql = "
       UPDATE csom 
-      SET comments = RIGHT(CONCAT(comments, CHAR(10), '$note'), 255)
+      SET comments = RIGHT(CONCAT(comments, CHAR(10), '$note'), 255),
           chg_user_id = '{$cp_automation_user}'
       
       WHERE invoice_nbr = $invoice_number -- chg_user_id = @user_id, chg_date = @today


### PR DESCRIPTION
I was reviewing the changes I made to https://github.com/dscsa/pharmacy/pull/208 and noticed a comma was missing. I don't think these changes were deployed on the server yet, please make sure this is merged before deploying the next changeset on the server.