### PR TITLE
csomline-deleted query

### DIFF
--- a/exports/export_cp_order_items.php
+++ b/exports/export_cp_order_items.php
@@ -27,6 +27,7 @@ function export_cp_remove_items($invoice_number, $items = [])
     $sql_to_update_deleted = "
         UPDATE CsOmLine_Deleted 
         SET chg_user_id = 1311
+        FROM CsOmLine_Deleted
         JOIN cprx ON cprx.rx_id = CsOmLine_Deleted.rx_id
         WHERE CsOmLine_Deleted.order_id = '{$order_id}'
         AND rxdisp_id = 0";


### PR DESCRIPTION
I'm not sure if this is standard sql or specific to sql server, but adding a join clause to an update requires you to redefine the table. I tested this on the dev server and it is valid syntax