### PR TITLE
check for rx_dispensed_id on all order items

### DIFF
--- a/updates/update_orders_cp.php
+++ b/updates/update_orders_cp.php
@@ -628,6 +628,30 @@ function cp_order_updated(array $updated) : ?array
             GPLog::notice($reason, [ 'order' => $order ]);
         }
 
+        /*
+         * Check to verify that all of the items in the order have an rx_dispensed_id
+         * If they do not then there is a problem and we should investigate the order further
+         */
+        $invalid_order_items = [];
+
+        foreach($order as $item) {
+            if (empty($item['rx_dispensed_id'] || is_null('rx_dispensed_id'))) {
+                $invalid_order_items[] = $item;
+            }
+        }
+
+        if (count($invalid_order_items) > 0) {
+            GPLog::critical(
+                "Order has items that are missing an rx_dispensed_id",
+                [
+                    'State Changed'                  => $stage_change_cp,
+                    'Updated'                        => $updated,
+                    'invoice_number'                 => $updated['invoice_number'],
+                    'items_missing_rx_dispensed_ids' => $invalid_order_items
+                ]
+            );
+        }
+
 
         if ($updated['order_date_shipped'] != $updated['old_order_date_shipped']) {
             AuditLog::log(
@@ -657,11 +681,11 @@ function cp_order_updated(array $updated) : ?array
             GPLog::critical(
                 "Order was shipped but not dispensed!",
                 [
-                    'State Changed' => $stage_change_cp,
-                    'Updated'       => $updated,
-                    'Dispensed-Check'     => ($updated['order_date_dispensed'] != $updated['old_order_date_dispensed']),
-                    'Shipped-Check'       => ($updated['order_date_shipped'] != $updated['old_order_date_shipped']),
-                    'invoice_number' => $updated['invoice_number']
+                    'State Changed'   => $stage_change_cp,
+                    'Updated'         => $updated,
+                    'Dispensed-Check' => ($updated['order_date_dispensed'] != $updated['old_order_date_dispensed']),
+                    'Shipped-Check'   => ($updated['order_date_shipped'] != $updated['old_order_date_shipped']),
+                    'invoice_number'  => $updated['invoice_number']
                 ]
             );
         }

--- a/updates/update_orders_cp.php
+++ b/updates/update_orders_cp.php
@@ -628,30 +628,6 @@ function cp_order_updated(array $updated) : ?array
             GPLog::notice($reason, [ 'order' => $order ]);
         }
 
-        /*
-         * Check to verify that all of the items in the order have an rx_dispensed_id
-         * If they do not then there is a problem and we should investigate the order further
-         */
-        $invalid_order_items = [];
-
-        foreach($order as $item) {
-            if (empty($item['rx_dispensed_id'] || is_null('rx_dispensed_id'))) {
-                $invalid_order_items[] = $item;
-            }
-        }
-
-        if (count($invalid_order_items) > 0) {
-            GPLog::critical(
-                "Order has items that are missing an rx_dispensed_id",
-                [
-                    'State Changed'                  => $stage_change_cp,
-                    'Updated'                        => $updated,
-                    'invoice_number'                 => $updated['invoice_number'],
-                    'items_missing_rx_dispensed_ids' => $invalid_order_items
-                ]
-            );
-        }
-
 
         if ($updated['order_date_shipped'] != $updated['old_order_date_shipped']) {
             AuditLog::log(
@@ -663,6 +639,30 @@ function cp_order_updated(array $updated) : ?array
                 ),
                 $updated
             );
+
+            /*
+            * Check to verify that all of the items in the order have an rx_dispensed_id
+            * If they do not then there is a problem and we should investigate the order further
+            */
+            $invalid_order_items = [];
+
+            foreach($order as $item) {
+                if (empty($item['rx_dispensed_id'] || is_null('rx_dispensed_id'))) {
+                    $invalid_order_items[] = $item;
+                }
+            }
+
+            if (count($invalid_order_items) > 0) {
+                GPLog::critical(
+                    "Order has items that are missing an rx_dispensed_id",
+                    [
+                        'State Changed'                  => $stage_change_cp,
+                        'Updated'                        => $updated,
+                        'invoice_number'                 => $updated['invoice_number'],
+                        'items_missing_rx_dispensed_ids' => $invalid_order_items
+                    ]
+                );
+            }
 
             GPLog::notice("Updated Order Shipped Started", [ 'order' => $order ]);
             $order = export_v2_unpend_order($order, $mysql, "Order Shipped");


### PR DESCRIPTION
Asana Task - https://app.asana.com/0/534557523548031/1199610544702764

Checking each item in the order when it's being shipped, sending an alert if the items don't all have an `rx_dispensed_id` This field is pulled from the `cprx_disp` table through the cp order items import.

I think this is the appropriate place to put this check, it's nested under an `if` statement that starts around line 595 to check if the order is shipped or dispensed. I can also add a comparison between `order_date_shipped` and `old_order_date_shipped` when I check the count of invalid items if that makes more sense