### PR TITLE
Handle Adds and Removes: Fix empty item

### DIFF
--- a/exports/export_v2_order_items.php
+++ b/exports/export_v2_order_items.php
@@ -235,6 +235,8 @@ function v2_unpend_item($item, $mysql, $reason)
             ),
             $item
         );
+
+        //  This is where the original PG alert was firing from
     }
 
     unpend_pick_list($item);

--- a/updates/update_order_items.php
+++ b/updates/update_order_items.php
@@ -10,6 +10,7 @@ use GoodPill\Logging\GPLog;
 use GoodPill\Logging\AuditLog;
 use GoodPill\Logging\CliLog;
 use GoodPill\Models\GpOrder;
+use GoodPill\Models\GpOrderItem;
 
 /**
  * Handle all the possible Item updates.  it will go through each type of change
@@ -539,7 +540,18 @@ function handle_adds_and_removes(array $orders_updated) : void
             } else {
                 //  Something is going wrong with load_full_order/load_full_item and the data is not returned
                 //  If the drug property isn't set, fetch the item model and construct the drug name
+                $model_item = GpOrderItem::where('rx_number', $item['rx_number'])->first();
+                $items[$model_item->getDrugName()] = $model_item;
+                $remove_item_names[] = $model_item->getDrugName();
 
+                GPLog::warning(
+                    'handle_adds_and_removes: Removing items but item data is missing',
+                    [
+                        'item' => $item,
+                        'updates_removed' => $updates['removed'],
+                        'model_item' => $model_item->toJson(),
+                    ]
+                );
             }
 
         }

--- a/updates/update_order_items.php
+++ b/updates/update_order_items.php
@@ -533,8 +533,15 @@ function handle_adds_and_removes(array $orders_updated) : void
         }
 
         foreach ($updates['removed'] as $item) {
-            $items[$item['drug']] = $item;
-            $remove_item_names[] = $item['drug'];
+            if (isset($item['drug'])) {
+                $items[$item['drug']] = $item;
+                $remove_item_names[] = $item['drug'];
+            } else {
+                //  Something is going wrong with load_full_order/load_full_item and the data is not returned
+                //  If the drug property isn't set, fetch the item model and construct the drug name
+
+            }
+
         }
 
         // an rx_number was swapped (e.g best_rx_number used instead) same


### PR DESCRIPTION
Task: https://app.asana.com/0/534557523548031/1200281818389413

Sometimes the `$item` contained in the `$updates` array is null or missing fields that should be present from `load_full_item`. the returned null data from `load_full_item` is merged with the items in the `$updated` array, missing fields by this point.

What I've done is added a check to see if each item to be removed has the expected `drug` field. If it doesn't, try to fetch the order item model and create the correct drug field, merge it all together, and continue executing. Shouldn't cause any problems further down with the `unpend_pick_list` function since it's currently not causing a problem and the original item data fields are still present in the merged object.

