### PR TITLE
Log Model data when alerting of shipped status

### DIFF
--- a/updates/update_order_items.php
+++ b/updates/update_order_items.php
@@ -325,7 +325,10 @@ function order_item_updated(array $updated) : ?array
     if ($GPOrder && $GPOrder->isShipped()) {
         GPLog::alert(
             "Trying to change an item on an order that has already shipped",
-            [ 'updated' => $updated]
+            [
+                'updated' => $updated,
+                'GpOrder' => $GPOrder->toJSON()
+            ]
         );
     }
 


### PR DESCRIPTION
Getting an increased number of pager duty alerts for this. I'm adding the model data at the moment the alert is fired so that I can see what the date shipped time is and if there's a tracking number. `isShipped` adds a 12 hour padding, I'm wondering if some of these alerts are happening because the order is changed slightly out of that 12 hour window.