### PR TITLE
Remove 3-5 days messaging Order Shipped Comms

### DIFF
--- a/exports/export_gd_comm_calendar.php
+++ b/exports/export_gd_comm_calendar.php
@@ -40,7 +40,7 @@ function order_shipped_notice($groups)
         // $shipping_event->publishEvent();
     }
 
-    $subject   = 'Good Pill shipped order '.($groups['ALL'][0]['count_filled'] ? 'of '.$groups['ALL'][0]['count_filled'].' items ' : '').'and it should arrive in 3-5 days.';
+    $subject   = 'Good Pill shipped order '.($groups['ALL'][0]['count_filled'] ? 'of '.$groups['ALL'][0]['count_filled'].' items ' : '');
     $message   = '';
 
     $message .= '<br><u>These Rxs are on the way:</u><br>'.implode(';<br>', $groups['FILLED']).';';


### PR DESCRIPTION
https://app.asana.com/0/534557523548031/1200363165085310

Since I was already looking at communications I removed the 3-5 day language from what currently exists. I didn't find any language for the SMS communication that is described in the ticket however. I'm not sure if the language in the asana task was incorrect or if I'm missing some place in the codebase