### PR TITLE
Fix Variable usage in update_drugs

### DIFF
--- a/updates/update_drugs.php
+++ b/updates/update_drugs.php
@@ -79,7 +79,7 @@ function drug_created(array $created) : void
 
     if ($created['drug_gsns']) {
         update_mismatched_rxs_and_items($mysql, $created);
-        update_field_rxs_single($mysql, $updated, 'drug_gsns'); //Now that everything is matched, we can update all rxs_single to the new gsn
+        update_field_rxs_single($mysql, $created, 'drug_gsns'); //Now that everything is matched, we can update all rxs_single to the new gsn
     }
 
     GPLog::resetSubroutineId();


### PR DESCRIPTION
Noticed this undefined variable in the update_drugs function. I'm not sure if this has been a problem that the pharmacy app is handling elsewhere, but I would have expected problems with this function a few months ago