### PR TITLE
#xt7p0c Cleanup for wc_post deletion

### DIFF
--- a/exports/export_wc_orders.php
+++ b/exports/export_wc_orders.php
@@ -297,6 +297,15 @@ function export_wc_delete_order($invoice_number, $reason)
             "export_wc_delete_order: Requested delete, but post_id missing",
             ['invoice_number' => $invoice_number, 'reason' => $reason ]
         );
+
+        GPLog::critical(
+            "export_wc_delete_order: post id is missing, need to review, check context",
+            [
+                'invoice_number' => $invoice_number,
+                'reason'         => $reason,
+                'details'        => 'Related to clickup task https://app.clickup.com/t/xt7p0c. Assign to Jesse'
+            ]
+        );
         return false;
     }
 

--- a/exports/export_wc_orders.php
+++ b/exports/export_wc_orders.php
@@ -30,7 +30,7 @@ function wc_get_post($invoice_number, $wc_order_key = null, $suppress_error = fa
 
     if (! $suppress_error) {
         // Make sure this order hasn't been deleted before we yell about it
-        $order = GpOrder::where('invoice_number', $invoice_number);
+        $order = GpOrder::find($invoice_number);
         if ($order) {
             GPLog::error(
                 "Order $invoice_number doesn't seem to exist in wp_posts",
@@ -298,14 +298,6 @@ function export_wc_delete_order($invoice_number, $reason)
             ['invoice_number' => $invoice_number, 'reason' => $reason ]
         );
 
-        GPLog::critical(
-            "export_wc_delete_order: post id is missing, need to review, check context",
-            [
-                'invoice_number' => $invoice_number,
-                'reason'         => $reason,
-                'details'        => 'Related to clickup task https://app.clickup.com/t/xt7p0c. Assign to Jesse'
-            ]
-        );
         return false;
     }
 

--- a/updates/update_orders_cp.php
+++ b/updates/update_orders_cp.php
@@ -424,20 +424,20 @@ function cp_order_deleted(array $deleted) : ?array
         );
 
         GPLog::warning(
-            'update_orders_cp deleted: their appears to be a replacement',
+            'update_orders_cp deleted: there appears to be a replacement',
             [
                 'deleted'     => $deleted,
                 'replacement' => $replacement,
-                'groups'      => $groups,
-                'patient'     => $patient
             ]
         );
 
         // TODO:BEN Add an if here to see if we even have a wp to delete
+        // wc_get_post automatically checks wp_posts: Jesse
         export_wc_delete_order(
             $deleted['invoice_number'],
             "update_orders_cp: cp order deleted but replacement"
         );
+
 
         return null;
     }
@@ -467,7 +467,9 @@ function cp_order_deleted(array $deleted) : ?array
             $deleted['invoice_number'],
             "update_orders_cp: cp order manually cancelled $reason"
         );
+
         // We passed in $deleted because there is not $order to make $groups
+        // @TODO There is no $groups variable here, is this ok to do??
         order_cancelled_notice($deleted, $groups);
     } elseif (is_webform($deleted)) {
         AuditLog::log(

--- a/updates/update_orders_cp.php
+++ b/updates/update_orders_cp.php
@@ -437,8 +437,7 @@ function cp_order_deleted(array $deleted) : ?array
             $deleted['invoice_number'],
             "update_orders_cp: cp order deleted but replacement"
         );
-
-
+        
         return null;
     }
 


### PR DESCRIPTION
Reviewing some cases where error logs are firing about missing a post_id these are expected. An rxs or cp_created event is eventually leading to orders not getting filled, the wc order has not been created yet in the database, so no post ID is found.

I fixed a small problem where a check for the order in the gp table would always throw because the model wasn't getting the first record or finding. It might make sense to change this log entry to a debug because of how often a there isn't a wc order when an order is being deleted https://github.com/dscsa/pharmacy/blob/main/exports/export_wc_orders.php#L296-L299