### PR TITLE
#y5ddhh - Helper Days And Message

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,5 +8,6 @@ cli/full_env.php
 webform
 .phpintel/
 .DS_STORE
+testing/*
 testing/mocks/*
 testing/secrets

--- a/classes/GoodPill/Models/DaysAndMessageHelper.php
+++ b/classes/GoodPill/Models/DaysAndMessageHelper.php
@@ -1,0 +1,48 @@
+<?php
+
+use GoodPill\Logging\GPLog;
+use GoodPill\Models\GpOrder;
+
+class DaysMessageHelper {
+    public static function getDaysAndMessage(DaysMessageInterface $item, GpOrder $order) {
+        $no_transfer = $item->isNoTransfer();
+        $added_manually = $item->isAddedManually();
+        $is_webform = $item->isWebform();
+        $not_offered = $item->isNotOffered();
+        $is_refill = $item->isRefill($order);
+        $is_refill_only = $item->isRefillOnly();
+        $is_not_rxs_parsed = $item->isNotRxsParsed();
+
+        $days_left_in_expiration = $item->getDaysLeftBeforeExpiration();
+        $days_left_in_refills = $item->getDaysLeftInRefills();
+        $days_left_in_stock = $item->getDaysLeftInStock();
+        $days_default = $item->getDaysDefault();
+        $date_added = $item->date_added;
+        $days_early_next = $item->days_early_next;
+        $days_early_default = $item->days_early_default;
+        $days_since = $item->days_since;
+
+        GPLog::debug(
+            "Days And Message Helper Refactor",
+            [
+                'item' => $item->toArray(),
+                'no_transfer' => $no_transfer,
+                'added_manually' => $added_manually,
+                'is_webform' => $is_webform,
+                'not_offered' => $not_offered,
+                'is_refill' => $is_refill,
+                'is_refill_only' => $is_refill_only,
+                //  'stock_level' => $stock_level, @todo make this a computed attribute
+                'is_not_rxs_parsed' => $is_not_rxs_parsed,
+                'days_left_in_expiration' => $days_left_in_expiration,
+                'days_left_in_refills' => $days_left_in_refills,
+                'days_left_in_stock' => $days_left_in_stock,
+                'days_default' => $days_default,
+                'date_added' => $date_added,
+                'days_early_next' => $days_early_next,
+                'days_early_default' => $days_early_default,
+                'days_since' => $days_since
+            ]
+        );
+    }
+}

--- a/classes/GoodPill/Models/DaysAndMessageInterface.php
+++ b/classes/GoodPill/Models/DaysAndMessageInterface.php
@@ -1,0 +1,20 @@
+<?php
+
+use GoodPill\Models\GpOrder;
+
+interface DaysMessageInterface {
+    public function isNoTransfer() : bool;
+    public function isAddedManually() : bool;
+    public function isWebform() : bool;
+    public function isNotOffered() : bool;
+    public function isRefill(GpOrder $order) : bool;
+    public function isRefillOnly() : bool;
+    public function isNotRxParsed() : bool;
+    //public function isDuplicateGsn() : bool;
+
+    public function getDaysLeftBeforeExpiration();
+    public function getDaysLeftInRefills();
+    public function getDaysLeftInStock();
+    public function getDaysDefault();
+
+}

--- a/classes/GoodPill/Models/GpOrder.php
+++ b/classes/GoodPill/Models/GpOrder.php
@@ -296,7 +296,6 @@ class GpOrder extends Model
                && in_array($this->order_source, ['Webform Refill', 'Refill w/ Note']);
     }
 
-
     /*
      * Other Methods
      */

--- a/classes/GoodPill/Models/GpOrderItem.php
+++ b/classes/GoodPill/Models/GpOrderItem.php
@@ -247,10 +247,13 @@ class GpOrderItem extends Model
      */
     public function isAutoRefill(): bool
     {
-        return in_array($this->order_source, ['Auto Refill v2', 'O Refills']);
+        return in_array($this->order->order_source, ['Auto Refill v2', 'O Refills']);
     }
 
     /**
+     * GpOrderItem
+     * @TODO - Decide what to do with this and corresponding grouped function
+     *
      * Determine by the stock level if the item is offered or not
      * @return bool
      */
@@ -261,18 +264,10 @@ class GpOrderItem extends Model
 
         $rx_gsn = $rxs->rx_gsn;
         $drug_name = $rxs->drug_name;
-        //  This should always be set, `stock_level` isn't null in the database for any items currently
+
+        //  For a GpOrderItem, a stock_level_initial exists, so this check is used
         $stock_level = $this->stock_level_initial ?: $stock->stock_level;
 
-        GPLog::debug(
-            "Stock Level for order #{$this->invoice_number}, rx #{$this->rx_number}: {$stock}",
-            [
-                'item' => $this->toJSON(),
-                'stock_level' => $stock_level,
-                'drug_name' => $drug_name,
-                'rx_gsn' => $rx_gsn,
-            ]
-        );
         if (
             $rx_gsn > 0 ||
             $stock_level == STOCK_LEVEL['NOT OFFERED'] ||
@@ -334,6 +329,11 @@ class GpOrderItem extends Model
         );
     }
 
+    /**
+     * Check stock level to see if this a one-time fill
+     * @TODO - Decide what to do with this and corresponding grouped function
+     * @return bool
+     */
     public function isOneTime()
     {
         $rxs = $this->rxs;
@@ -346,14 +346,6 @@ class GpOrderItem extends Model
                 STOCK_LEVEL['ONE TIME']
             ]
         );
-    }
-
-
-    //  This needs to be renamed
-    //  @TODO - Rename this, part of the syncable functional grouping
-    public function isSyncable() : bool
-    {
-        return ($this->is_order && !$this->item_date_added && !$this->order->order_date_dispensed);
     }
 
     /**

--- a/classes/GoodPill/Models/GpOrderItem.php
+++ b/classes/GoodPill/Models/GpOrderItem.php
@@ -260,6 +260,28 @@ class GpOrderItem extends Model
 
         return false;
     }
+
+    /**
+     *
+     * @return bool
+     */
+    public function shouldSyncToOrderPastDue() : bool
+    {
+        if (!$this->item_date_added)
+        {
+            $has_refills = ($this->refills_total > NO_REFILL);
+
+            $is_refill = $this->refill_date_first;
+
+            $eligible = (
+                $has_refills &&
+                $this->refill_date_next &&
+                (strtotime($this->refill_date_next) - strtotime($this->order_date_added)) < 0
+            );
+            return $eligible;
+        }
+        return false;
+    }
     /*
         ## ACCESSORS
      */

--- a/classes/GoodPill/Models/GpOrderItem.php
+++ b/classes/GoodPill/Models/GpOrderItem.php
@@ -236,8 +236,8 @@ class GpOrderItem extends Model
     function isAddedManually($item)
     {
         return
-            in_array($this->item_added_by, ADDED_MANUALLY) or
-            ($this->item_date_added and $this->refill_date_manual and $this->order->is_auto_refill());
+            in_array($this->item_added_by, ADDED_MANUALLY) ||
+            ($this->item_date_added && $this->refill_date_manual && $this->order->is_auto_refill());
     }
 
     /**
@@ -294,11 +294,6 @@ class GpOrderItem extends Model
     public function isNoTransfer() : bool
     {
         return $this->isHighPrice() || $this->patient->pharmacy_phone === '8889875187';
-    }
-
-    public function isWebformRefill() : bool
-    {
-
     }
 
     //  This needs to be renamed

--- a/classes/GoodPill/Models/GpPatient.php
+++ b/classes/GoodPill/Models/GpPatient.php
@@ -161,6 +161,11 @@ class GpPatient extends Model
         return $this->hasOne(CpPat::class, 'pat_id', 'patient_id_cp');
     }
 
+    public function groupedRxs()
+    {
+        return $this->hasMany(GpRxsGrouped::class, 'patient_id_cp', 'patient_id_cp');
+    }
+
     /*
      * Mutators
      */

--- a/classes/GoodPill/Models/GpRxsGrouped.php
+++ b/classes/GoodPill/Models/GpRxsGrouped.php
@@ -101,6 +101,78 @@ class GpRxsGrouped extends Model
     protected $fillable = [];
 
     /**
+     * Relationships
+     */
+
+    /**
+     * Relationship to a patient
+     * @return \Illuminate\Database\Eloquent\Relations\BelongsTo
+     */
+    public function patient()
+    {
+        return $this->belongsTo(GpPatient::class, 'patient_id_cp', 'patient_id_cp');
+    }
+    /**
+     * Relationship to Gp Stock Live
+     * @return \Illuminate\Database\Eloquent\Relations\HasOne
+     */
+    public function stock()
+    {
+        return $this->hasOne(GpStockLive::class, 'drug_generic', 'drug_generic');
+    }
+
+    /**
+     * Relationship to Gp Rxs Single
+     * Matches on `best_rx_number`, should be careful when using this
+     * @return \Illuminate\Database\Eloquent\Relations\HasOne
+     */
+    public function rxs()
+    {
+        return $this->hasOne(GpRxsSingle::class, 'rx_number', 'best_rxs_number');
+    }
+    /**
+     * Checks to see if the grouped item is in an order
+     * @param $rx_number
+     * @return bool
+     */
+    public function findRxNumber($rx_number) : bool
+    {
+        //echo "$rx_number passed \n";
+        //echo "Grouped Items: $this->rx_numbers \n";
+        $needle = ",$rx_number,";
+        //echo "$needle \n";
+        $found = strpos($this->rx_numbers,",$rx_number,");
+        if ($found === false) {
+            return false;
+        } else {
+            //echo "We found $rx_number in grouped";
+            return true;
+        }
+    }
+
+    /**
+     * Checks an order to see if the grouped item already exists in it
+     * @param GpOrder $order
+     * @return bool
+     */
+    public function isInOrder(GpOrder $order) : bool {
+        $orderItems = $order->items;
+        $found = $orderItems->filter(function($orderItem) {
+            $is_found = $this->findRxNumber($orderItem->rx_number);
+            if ($is_found === true) {
+                return true;
+            } else {
+                return false;
+            }
+        });
+
+        if ($found->count() > 0) {
+            return true;
+        } else {
+            return false;
+        }
+    }
+    /**
      * Checks that item has refills available
      * @return bool
      */
@@ -109,26 +181,40 @@ class GpRxsGrouped extends Model
         return $this->refills_total > NO_REFILL;
     }
 
-    /*
-     * The following functions do not currently work
-     *
-     * Should these syncing functions be on a grouped entity?
-     * RxsGrouped would need duplicated logic from what is on GpOrderItem
-     *
+    /**
+     * Checks to see if the stock price is high
+     * @return bool
      */
+    public function isHighPrice() : bool
+    {
+        $price_per_month = $this->stock->price_per_month;
+
+        return $price_per_month >= 20;
+    }
+
+    /**
+     * Determines if we should not transfer out items
+     * Checks for a high price or to see if the patient's backup pharmacy is us
+     *
+     * @return bool
+     */
+    public function isNoTransfer() : bool
+    {
+        return $this->isHighPrice() || $this->patient->pharmacy_phone === '8889875187';
+    }
+
     /**
      * Determine by the stock level if the item is offered or not
+     * @TODO - Logic for this if grouped, ignore rx_gsn?
      * @return bool
      */
     public function isNotOffered() : bool
     {
         $rxs = $this->rxs;
-        $stock = $rxs->stock;
+        $stock_level = $this->stock->stock_level;
 
         $rx_gsn = $rxs->rx_gsn;
         $drug_name = $rxs->drug_name;
-        //  This should always be set, `stock_level` isn't null in the database for any items currently
-        $stock_level = $this->stock_level_initial ?: $stock->stock_level;
 
         GPLog::debug(
             "Stock Level for order #{$this->invoice_number}, rx #{$this->rx_number}: {$stock}",
@@ -150,6 +236,82 @@ class GpRxsGrouped extends Model
         return false;
     }
 
+    /**
+     * Check if the item is set to only refill for the order
+     * @return bool
+     */
+    public function isRefillOnly() : bool
+    {
+        $stock_level = $this->stock->stock_level;
+        return in_array(
+            $stock_level,
+            [
+                STOCK_LEVEL['OUT OF STOCK'],
+                STOCK_LEVEL['REFILL ONLY']
+            ]
+        );
+    }
+
+    public function isOneTime() : bool
+    {
+        $stock_level = $this->stock->stock_level;
+        return in_array(
+            $stock_level,
+            [
+                STOCK_LEVEL['ONE TIME']
+            ]
+        );
+    }
+
+    /**
+     * Checks if this item happens to already be in an order under same name
+     * matches drug_generic rather than rx_number
+     * @TODO clarify with Adam what this means
+     * @param GpOrder $order
+     * @return bool
+     */
+    function isRefill(GpOrder $order) : bool
+    {
+        foreach ($order->items as $orderItem) {
+            if (
+                $this->drug_generic == $orderItem->drug_generic
+                && $orderItem->refill_date_first
+            ) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    /**
+     * Determines if the rx was ever parsed
+     * This is based on there being on sig_qty_per_day_default
+     * Rxs single will have mismatched refills original vs refills left
+     * @return bool
+     */
+    public function isNotRxParsed() : bool
+    {
+        if (
+            !$this->rxs->sig_qty_per_day_default &&
+            $this->rxs->refills_original != $this->rxs->refills_left
+        ) {
+            return true;
+        }
+        return false;
+    }
+
+    /**
+     * Determine if the item can be synced to the order
+     * @TODO what does it really mean to be syncable
+     * @return bool
+     */
+    public function isSyncable() : bool
+    {
+       // is_order
+        //! item_date_added
+        //! order_date_dispensed
+    }
     /**
      * Add the item to an order if it's a new rx found
      * @return bool
@@ -176,5 +338,157 @@ class GpRxsGrouped extends Model
         }
 
         return false;
+    }
+
+    public function getRxDateWrittenAttribute()
+    {
+        return  strtotime($this->rx_date_expired . ' -1 year');
+    }
+
+    //  currently an alias
+    public function getDateAddedAttribute()
+    {
+        return $this->rx_date_written;
+    }
+
+    public function getDaysEarlyNextAttribute()
+    {
+        return strtotime($this->refill_date_next) - strtotime($this->date_added);
+    }
+
+    public function getDaysEarlyDefaultAttribute()
+    {
+        return strtotime($this->refill_date_default) - strtotime($this->date_added);
+    }
+
+    public function getDaysSinceAttribute()
+    {
+        return strtotime($this->date_added) - strtotime($this->refill_date_last);
+    }
+
+    /**
+     * Gets the days left before an rx expires
+     * @return float|int|null
+     */
+    public function getDaysLeftBeforeExpiration()
+    {
+        $rxs = $this->rxs;
+        //Usually don't like using time() because it can change, but in this case once it is marked as expired it will always be expired so there is no variability
+        $comparison_date = $this->refill_date_next ? strtotime($this->refill_date_next) : time();
+
+        $days_left_in_expiration = (strtotime($this->rx_date_expired) - $comparison_date)/60/60/24;
+
+        //#29005 was expired but never dispensed, so check "refill_date_first" so we asking doctors for new rxs that we never dispensed
+        if ($this->refill_date_first) {
+            return $days_left_in_expiration;
+        }
+
+        return null;
+    }
+
+    /**
+     * Checks to make sure sig qty is set and reasonable
+     * If the qty per day > 10 we think that the sig parser might be off
+     * @return bool
+     */
+    public function isSigParsingVerified() : bool
+    {
+        if (
+            !$this->sig_qty_per_day ||
+            $this->sig_qty_per_day > 10
+        ) {
+            return false;
+        }
+
+        return true;
+    }
+
+    /**
+     * Determines the number of days left for the current rx refill
+     * @return float|int|null
+     */
+    public function getDaysLeftInRefills()
+    {
+        if (!$this->isSigParsingVerified())
+        {
+            return null;
+        }
+
+        //Uncomment the line below if we are okay dispensign 2 bottles/rxs.  For now, we will just fill the most we can do with one Rx.
+        //if ($item['refills_total'] != $item['refills_left']) return; //Just because we are out of refills on this script doesn't mean there isn't another script with refills
+
+        $days_left_in_refills = $this->rxs->qty_left / $this->sig_qty_per_day;
+
+        //Fill up to 30 days more to finish up an Rx if almost finished.
+        //E.g., If 30 day script with 3 refills (4 fills total, 120 days total) then we want to 1x 120 and not 1x 90 + 1x30
+        if ($days_left_in_refills <= DAYS_MAX) {
+            return $this->roundDaysUnit($days_left_in_refills);
+        }
+
+        return null;
+    }
+
+    /**
+     * Determines the number of days left in stock
+     * Returns either 60.6 or `DAYS_MIN` of 45
+     * @return float|int|void
+     */
+    public function getDaysLeftInStock()
+    {
+        if (!$this->isSigParsingVerified())
+        {
+            return null;
+        }
+
+        $live_stock = $this->stock;
+
+        $days_left_in_stock = round($live_stock->last_inventory / $this->sig_qty_per_day);
+
+        if (
+            $days_left_in_stock >= DAYS_STD ||
+            $live_stock->last_inventory >= 3 *$live_stock->qty_repack
+        ) {
+            return null;
+        }
+
+        //Dispensed 2 inhalers per time, since 1/30 is rounded to 3 decimals (.033), 2 month/.033 = 60.6 qty
+        return $this->rxs->sig_qty_per_day_default === round(1/30, 3) ? 60.6 : DAYS_MIN;
+    }
+
+    /**
+     * Determines the number of default days to return for days_and_messages
+     *
+     * This is the MIN of ($days_left_in_refills, $days_left_in_stock). If either
+     * value is 0, Use the DAY_STD in its place
+     *
+     * This is really more $days_to_fill.  It's not the default, but it's what
+     * we've determined as the max amount we can fill
+     * @return mixed
+     */
+    public function getDaysDefault()
+    {
+        $days_left_in_refills = $this->getDaysLeftInRefills();
+        $days_left_in_stock = $this->getDaysLeftInStock();
+
+        $days = min(
+            $days_left_in_refills ?: DAYS_STD,
+            $days_left_in_stock ?: DAYS_STD
+        );
+        //  This is used for generating logs. Skipping logging from class methods
+        //$remainder = $days % DAYS_UNIT;
+
+        return $days;
+    }
+
+    /**
+     * Returns the rounded number of days
+     * @param $days
+     * @return float|int
+     */
+    public function roundDaysUnit($days)
+    {
+        //+.1 because we had 18qty with .201 sig_qty_per_day_default which gave floor(5.97) -> 75 days instead of 90
+        //Bactrim with 6 qty and 2.0 sig_qty_per_day_default which gave floor(6/2/15) -> 0 days
+        return $days < DAYS_UNIT ? $days : floor($days/DAYS_UNIT+.1)*DAYS_UNIT; //+.1 because we had 18qty with .201 sig_qty_per_day_default which gave floor(5.97) -> 75 days instead of 90
     }
 }

--- a/classes/GoodPill/Models/GpRxsSingle.php
+++ b/classes/GoodPill/Models/GpRxsSingle.php
@@ -154,6 +154,25 @@ class GpRxsSingle extends Model
     }
 
     /**
+     * Relationship to an order
+     * There is no direct reference to an order from an rxs, so hasOneThrough is used
+     * @return \Illuminate\Database\Eloquent\Relations\HasOneThrough
+     */
+    public function order()
+    {
+        return $this->hasOneThrough(GpOrder::class, GpOrderItem::class);
+    }
+
+    /**
+     * Relationship to an order item
+     * @return \Illuminate\Database\Eloquent\Relations\BelongsTo
+     */
+    public function orderitem()
+    {
+        return $this->belongsTo(GpOrderItem::class, 'rx_number', 'rx_number');
+    }
+
+    /**
      * Loads the GpRxsGrouped data into an rxs single item
      * Because there is no traditional relationship that laravel can make, we have to pseudo-load the data
      * When inspecting an order item, if you fetch the rxs for that item you would need to call this function

--- a/helpers/helper_days_and_message.php
+++ b/helpers/helper_days_and_message.php
@@ -547,6 +547,10 @@ function set_days_and_message($item, $days, $message, $mysql) {
     return $item;
 }
 
+/**
+ * Refactored into GpOrderItem as `calculateRefillsDispensedDefault`
+ * This is an oddly used function, need to reconsider its use
+ */
 function refills_dispensed_default($item)
 {
     if ($item['qty_total'] <= 0) { //Not sure if decimal 0.00 evaluates to falsey in PHP

--- a/helpers/helper_full_fields.php
+++ b/helpers/helper_full_fields.php
@@ -1,6 +1,8 @@
 
 <?php
 
+use GoodPill\Models\GpOrderItem;
+use GoodPill\Models\GpRxsGrouped;
 use GoodPill\Logging\{
     GPLog,
     AuditLog,
@@ -121,6 +123,24 @@ function add_full_fields($patient_or_order, $mysql, $overwrite_rx_messages)
         if ($set_days_and_msgs or $overwrite) {
 
             list($days, $message) = get_days_and_message($patient_or_order[$i], $patient_or_order);
+
+            /*
+             *  Refactored Model Code
+             * Used for comparisons currently
+             * Need to observe logs and compare to actual production values
+             *
+             */
+            if ($patient_or_order[0]['is_order'] && $patient_or_order[$i]['item_date_added']) {
+                $item = GpOrderItem::where('invoice_number', $patient_or_order[$i]['invoice_number'])
+                    ->where('rx_number', $patient_or_order[$i]['rx_number'])
+                    ->first();
+                DaysMessageHelper::getDaysAndMessage($item);
+            } else {
+                $item = GpRxsGrouped::find();
+                DaysMessageHelper::getDaysAndMessage($item);
+            }
+
+
 
             //If days_actual are set, then $days will be 0 (because it will be a recent fill)
             $days_added      = (@$patient_or_order[$i]['item_date_added'] AND $days > 0 AND ! @$patient_or_order[$i]['days_dispensed_default']);

--- a/helpers/helper_models.php
+++ b/helpers/helper_models.php
@@ -1,0 +1,10 @@
+<?php
+
+/**
+ * This is only for helper functions specifically using models
+ * Ideally, every single method will take a model or item as input
+ * and return something as the output to be used
+ *
+ * No data should be set on a model from a function
+ */
+

--- a/helpers/helper_models.php
+++ b/helpers/helper_models.php
@@ -4,15 +4,6 @@ use GoodPill\Models\GpOrder;
 use GoodPill\Models\GpOrderItem;
 use GoodPill\Models\GpRxsGrouped;
 use GoodPill\Models\GpRxsSingle;
-
-/**
- * This is only for helper functions specifically using models
- * Ideally, every single method will take a model or item as input
- * and return something as the output to be used
- *
- * No data should be set on a model from a function
- */
-
 /**
 
 Scaffolding test code to simulate load_full_order and passing in data
@@ -69,7 +60,7 @@ function get_days_and_message($item, GpOrder $order) {
     $days_left_before_expiration = $item->getDaysLeftBeforeExpiration();
     $days_left_in_refills = $item->getDaysLeftInRefills();
     $days_left_in_stock = $item->getDaysLeftInStock();
-    $days_default = $item->days_default();
+    $days_default = $item->getDaysDefault();
 
     $is_not_rx_parsed = $item->isNotRxParsed();
 

--- a/helpers/helper_models.php
+++ b/helpers/helper_models.php
@@ -1,5 +1,10 @@
 <?php
 
+use GoodPill\Models\GpOrder;
+use GoodPill\Models\GpOrderItem;
+use GoodPill\Models\GpRxsGrouped;
+use GoodPill\Models\GpRxsSingle;
+
 /**
  * This is only for helper functions specifically using models
  * Ideally, every single method will take a model or item as input
@@ -8,3 +13,87 @@
  * No data should be set on a model from a function
  */
 
+/**
+
+Scaffolding test code to simulate load_full_order and passing in data
+echo "------------ \n";
+$order->items->each(function($item) {
+echo "$item->rx_number \n";
+});
+
+echo "============= \n";
+
+$grouped->each(function($item) use ($order) {
+//get_days_and_message($item, $order);
+});
+ */
+
+
+
+
+function get_days_and_message($item, GpOrder $order) {
+
+    echo "$item->drug_name - $item->rx_number from top \n";
+    if ($item instanceof GpOrderItem) {
+        $is_order = true;
+        $is_item = false;
+        $is_patient = false;
+
+        $is_added_manually = $item->isAddedManually();
+        $is_webform = $item->isWebform();
+        $is_syncable = false;
+
+    }
+
+    if ($item instanceof GpRxsGrouped) {
+        $is_order = true;
+        $is_item = false;
+        $is_patient = false;
+
+        $is_not_offered = $item->is_not_offered();
+        $is_in_order = $item->isInOrder($order);
+        $is_added_manually = false;
+        $is_webform = false;
+        $is_syncable = !$is_in_order;
+    }
+
+
+    $is_no_transfer = $item->isNoTransfer();
+    //  Need to revisit isRefill
+    $is_refill = $item->isRefill($order);
+
+    $is_refill_only = $item->isRefillOnly();
+    $days_left_before_expiration = $item->getDaysLeftBeforeExpiration();
+    $days_left_in_refills = $item->getDaysLeftInRefills();
+    $days_left_in_stock = $item->getDaysLeftInStock();
+    $days_default = $item->days_default();
+
+    $is_not_rx_parsed = $item->isNotRxParsed();
+
+    // These are now all computed accessors on the GpRxsGrouped Entity
+    /*
+    $date_added = @$item['order_date_added'] ?: $item['rx_date_written'];
+    $days_early_next = strtotime($item['refill_date_next']) - strtotime($date_added);
+    $days_early_default = strtotime($item['refill_date_default']) - strtotime($date_added);
+    $days_since = strtotime($date_added) - strtotime($item['refill_date_last']);
+    */
+
+    /*
+  There was some error parsint the Rx
+ */
+
+    if ($is_not_rx_parsed) {
+        //  Throw a an error log
+        //log_error("helper_days_and_message: RX WAS NEVER PARSED", $item);
+    }
+
+    /*
+      We have multiple occurances of drugs on the same order
+     */
+    if (@$item['item_date_added'] and $is_duplicate_gsn) {
+        log_error("helper_days_and_message: $item[drug_generic] is duplicate GSN.  Likely Mistake. Different sig_qty_per_day?", ['item' => $item, 'order' => $patient_or_order]);
+    }
+
+
+    return true;
+}

--- a/helpers/helper_models.php
+++ b/helpers/helper_models.php
@@ -50,7 +50,7 @@ function get_days_and_message($item, GpOrder $order) {
         $is_item = false;
         $is_patient = false;
 
-        $is_not_offered = $item->is_not_offered();
+        $is_not_offered = $item->isNotOffered();
         $is_in_order = $item->isInOrder($order);
         $is_added_manually = false;
         $is_webform = false;

--- a/helpers/helper_models.php
+++ b/helpers/helper_models.php
@@ -32,6 +32,9 @@ $grouped->each(function($item) use ($order) {
 
 
 function get_days_and_message($item, GpOrder $order) {
+    // @TODO move to instances
+    //  Right now we need to check $item for many conditions and then
+    //  instanciate a model based off the different criteria
 
     echo "$item->drug_name - $item->rx_number from top \n";
     if ($item instanceof GpOrderItem) {


### PR DESCRIPTION
- Adds new relationships, functions, computed properties to GpOrderItems, GpRxsGrouped, GpPatient, GpRxsSingle
- Added a DaysAndMessage interface and helper under the models directly to enforce functions on GpOrder and GpRxsGrouped classes.
- Added code into `helper_full_fields` to use the models and log the data it would return.

There is a model helper file that can be ignored, it was used for testing, and should be removed.