### PR TITLE
Fix Comms Calendar For Translations

### DIFF
--- a/helpers/helper_calendar.php
+++ b/helpers/helper_calendar.php
@@ -407,7 +407,7 @@ function new_comm_arr($patient_label, $email = '', $text = '', $salesforce = '',
         }
 
         $text['message'] = format_text($text['message']);
-        if (strtoupper($language)) {
+        if (strtoupper($language) !== 'EN') {
             $text['language'] = $language;
         }
 

--- a/helpers/helper_calendar.php
+++ b/helpers/helper_calendar.php
@@ -383,7 +383,9 @@ function new_comm_arr($patient_label, $email = '', $text = '', $salesforce = '',
         $auto[] = "Email";
         $email['bcc']  = DEBUG_EMAIL;
         $email['from'] = 'Good Pill Pharmacy < support@goodpill.org >'; //spaces inside <> are so that google cal doesn't get rid of "HTML" if user edits description
-        $email['language'] = $language;
+        if ($language === 'es' || $language === 'ES') {
+            $email['language'] = $language;
+        }
         $comm_arr[] = $email;
     }
 

--- a/helpers/helper_calendar.php
+++ b/helpers/helper_calendar.php
@@ -372,6 +372,7 @@ function new_comm_arr($patient_label, $email = '', $text = '', $salesforce = '',
     $comm_arr = [];
     $auto     = [];
     $auto_salesforce = false;
+    $translated_language = strtoupper($language);
 
     if (! LIVE_MODE) {
         return $comm_arr;
@@ -383,8 +384,9 @@ function new_comm_arr($patient_label, $email = '', $text = '', $salesforce = '',
         $auto[] = "Email";
         $email['bcc']  = DEBUG_EMAIL;
         $email['from'] = 'Good Pill Pharmacy < support@goodpill.org >'; //spaces inside <> are so that google cal doesn't get rid of "HTML" if user edits description
-        if (strtoupper($language) !== 'EN') {
-            $email['language'] = $language;
+
+        if ($translated_language !== 'EN') {
+            $email['language'] = $translated_language;
         }
         $comm_arr[] = $email;
     }
@@ -407,8 +409,9 @@ function new_comm_arr($patient_label, $email = '', $text = '', $salesforce = '',
         }
 
         $text['message'] = format_text($text['message']);
-        if (strtoupper($language) !== 'EN') {
-            $text['language'] = $language;
+
+        if ($translated_language !== 'EN') {
+            $text['language'] = $translated_language;
         }
 
         if (! @$text['fallbacks']) { //Default to a call fallback if SMS fails

--- a/helpers/helper_calendar.php
+++ b/helpers/helper_calendar.php
@@ -367,12 +367,11 @@ function confirm_shipment_event($order, $email, $text, $salesforce, $hours_to_wa
     create_event($event_title, $comm_arr, $hours_to_wait, $time_of_day);
 }
 
-function new_comm_arr($patient_label, $email = '', $text = '', $salesforce = '', $language = 'en')
+function new_comm_arr($patient_label, $email = '', $text = '', $salesforce = '', $language = 'EN')
 {
     $comm_arr = [];
     $auto     = [];
     $auto_salesforce = false;
-    $translation_language = strtolower($language);
 
     if (! LIVE_MODE) {
         return $comm_arr;
@@ -384,8 +383,8 @@ function new_comm_arr($patient_label, $email = '', $text = '', $salesforce = '',
         $auto[] = "Email";
         $email['bcc']  = DEBUG_EMAIL;
         $email['from'] = 'Good Pill Pharmacy < support@goodpill.org >'; //spaces inside <> are so that google cal doesn't get rid of "HTML" if user edits description
-        if ($translation_language !== 'en') {
-            $email['language'] = $translation_language;
+        if (strtoupper($language) !== 'EN') {
+            $email['language'] = $language;
         }
         $comm_arr[] = $email;
     }
@@ -408,8 +407,8 @@ function new_comm_arr($patient_label, $email = '', $text = '', $salesforce = '',
         }
 
         $text['message'] = format_text($text['message']);
-        if ($translation_language !== 'en') {
-            $text['language'] = $translation_language;
+        if (strtoupper($language)) {
+            $text['language'] = $language;
         }
 
         if (! @$text['fallbacks']) { //Default to a call fallback if SMS fails

--- a/helpers/helper_calendar.php
+++ b/helpers/helper_calendar.php
@@ -367,11 +367,12 @@ function confirm_shipment_event($order, $email, $text, $salesforce, $hours_to_wa
     create_event($event_title, $comm_arr, $hours_to_wait, $time_of_day);
 }
 
-function new_comm_arr($patient_label, $email = '', $text = '', $salesforce = '', $language = 'EN')
+function new_comm_arr($patient_label, $email = '', $text = '', $salesforce = '', $language = 'en')
 {
     $comm_arr = [];
     $auto     = [];
     $auto_salesforce = false;
+    $translation_language = strtolower($language);
 
     if (! LIVE_MODE) {
         return $comm_arr;
@@ -383,8 +384,8 @@ function new_comm_arr($patient_label, $email = '', $text = '', $salesforce = '',
         $auto[] = "Email";
         $email['bcc']  = DEBUG_EMAIL;
         $email['from'] = 'Good Pill Pharmacy < support@goodpill.org >'; //spaces inside <> are so that google cal doesn't get rid of "HTML" if user edits description
-        if ($language !== 'en' && $language !== 'EN') {
-            $email['language'] = $language;
+        if ($translation_language !== 'en') {
+            $email['language'] = $translation_language;
         }
         $comm_arr[] = $email;
     }
@@ -407,7 +408,9 @@ function new_comm_arr($patient_label, $email = '', $text = '', $salesforce = '',
         }
 
         $text['message'] = format_text($text['message']);
-        $text['language'] = $language;
+        if ($translation_language !== 'en') {
+            $text['language'] = $translation_language;
+        }
 
         if (! @$text['fallbacks']) { //Default to a call fallback if SMS fails
 

--- a/helpers/helper_calendar.php
+++ b/helpers/helper_calendar.php
@@ -383,7 +383,7 @@ function new_comm_arr($patient_label, $email = '', $text = '', $salesforce = '',
         $auto[] = "Email";
         $email['bcc']  = DEBUG_EMAIL;
         $email['from'] = 'Good Pill Pharmacy < support@goodpill.org >'; //spaces inside <> are so that google cal doesn't get rid of "HTML" if user edits description
-        if ($language === 'es' || $language === 'ES') {
+        if ($language !== 'en' && $language !== 'EN') {
             $email['language'] = $language;
         }
         $comm_arr[] = $email;


### PR DESCRIPTION
- Translations return an error when using default EN because it can't translate from the same language. Added a conditional to append the language to a `language` attribute only if it is Spanish