### PR TITLE
#xt7nz3 - New Patient Registration and Reminder

### DIFF
--- a/classes/GoodPill/Events/Patient/NewPatientRegister.php
+++ b/classes/GoodPill/Events/Patient/NewPatientRegister.php
@@ -1,0 +1,219 @@
+<?php
+
+namespace GoodPill\Events\Patient;
+
+use GoodPill\Events\Event;
+use GoodPill\Events\SalesforceComm;
+use GoodPill\Events\EmailComm;
+use GoodPill\Events\SmsComm;
+use GoodPill\Models\GpPatient;
+
+/**
+ * A Class to define the event when a CarepointPatientLabel has changed
+ */
+class NewPatientRegister extends Event
+{
+    /**
+     * Hold the patient for this event
+     * @var GoodPill\Models\GpPatient
+     */
+    protected $patient;
+
+    /**
+     * Hold the patient data that is used to render the messages
+     * @var array
+     */
+    protected $patient_data;
+
+    /**
+     * More data that will be added to the base patient data
+     * @var array
+     */
+    protected $additional_data = [];
+
+    /**
+     * The $groups data that is needed to determine when to send the message and drugs to list
+     * @var null
+     */
+    protected $groups = null;
+
+    /**
+     * The type of event.  This is used for the event title
+     * @var string
+     */
+    public $type;
+
+    /**
+     * Should be defined by Child class
+     * @var string
+     */
+    protected $template_path = 'Patient/NewPatientRegister';
+
+    /**
+     * Make it so
+     * @param GpPatient|null $patient Optional. Will preset the patient if passed.
+     */
+    public function __construct(?GpPatient $patient = null, $groups = null)
+    {
+        $this->type = 'New Patient Register';
+        $this->groups = $groups;
+
+        if (!is_null($patient)) {
+            $this->setPatient($patient);
+        }
+
+        $hour_added = substr($groups['ALL'][0]['order_date_added'], 11, 2);
+
+        if ($hour_added < 10) {
+            //A if before 10am, the first one is at 10am, the next one is 5pm, then 10am tomorrow, then 5pm tomorrow
+            $this->hours_to_wait = [0, 0, 24, 24, 24*7, 24*14];
+            $this->hour_of_day   = ['11:00', '17:00', '11:00', '17:00', '17:00', '17:00'];
+        } elseif ($hour_added < 17) {
+            //A if before 5pm, the first one is 10mins from now, the next one is 5pm, then 10am tomorrow, then 5pm tomorrow
+            $this->hours_to_wait = [10/60, 0, 24, 24, 24*7, 24*14];
+            $this->hour_of_day   = [0, '17:00', '11:00', '17:00', '17:00', '17:00'];
+        } else {
+            //B if after 5pm, the first one is 10am tomorrow, 5pm tomorrow, 10am the day after tomorrow, 5pm day after tomorrow.
+            $this->hours_to_wait = [24, 24, 48, 48, 24*7, 24*14];
+            $this->hour_of_day   = ['11:00', '17:00', '11:00', '17:00', '17:00', '17:00'];
+        }
+    }
+
+    /**
+     * Set the patient for this event
+     * @param GpPatient $patient The patient.
+     * @return void
+     */
+    public function setPatient(GpPatient $patient) : void
+    {
+        $this->patient = $patient;
+    }
+
+    /**
+     * An array of data to add to the data available to the templates
+     * @param array $data Anything you would like to add.
+     * @return void
+     */
+    public function setAdditionalData(array $data) : void
+    {
+        $this->additional_data = $data;
+    }
+
+    /**
+     * The the data about a patient so the template can be rendered
+     * @return string
+     */
+    public function getPatientData() : array
+    {
+        $patient = $this->patient;
+        $data    = $patient->toArray();
+
+        if (!empty($this->additional_data)) {
+            $data['additional'] = $this->additional_data;
+        }
+
+        if (! is_null($this->groups)) {
+            $data['groups'] = $this->groups;
+            $data['provider'] = [
+                'provider_first_name' => $this->groups['ALL'][0]['provider_first_name'],
+                'provider_last_name' => $this->groups['ALL'][0]['provider_last_name'],
+                'provider_clinic' => $this->groups['ALL'][0]['provider_clinic'],
+                'provider_phone' => $this->groups['ALL'][0]['provider_phone']
+            ];
+            $data['order_items'] = $this->groups['NOFILL_ACTION'];
+        }
+
+        return $data;
+    }
+
+    /**
+     * Get the email portion of a communication
+     * @return EmailComm
+     */
+    public function getEmail() : ?EmailComm
+    {
+        if (empty($this->patient->email)) {
+            echo "There Is No Patient Email \n";
+            return null;
+        }
+        $email              = new EmailComm();
+        $email->subject     = $this->render('email_subject');
+        $email->message     = $this->render('email');
+        $email->email       = $this->patient->email;
+
+        return $email;
+    }
+
+    /**
+     * Generate the SMS part of the communication Event
+     * @return SmsComm
+     */
+    public function getSms() : ?SmsComm
+    {
+        return null;
+    }
+
+    /**
+     * Generate the Salesforce portion of the Communication event
+     * @return SalesforceComm
+     */
+    public function getSalesforce() : ?SalesforceComm
+    {
+        if (! $this->patient instanceof GpPatient) {
+            return null;
+        }
+
+        $patient               = $this->patient;
+        $salesforce            = new SalesforceComm();
+        $salesforce->contact   = $this->patient->getPatientLabel();
+        $salesforce->subject   = "Call to Register Patient";
+        $salesforce->body      = $this->render('salesforce');
+        $salesforce->assign_to = '.Missing Contact Info';
+        return $salesforce;
+    }
+
+    /**
+     * Get the title for the event.
+     * @return string
+     */
+    public function getTitle() : string
+    {
+        return sprintf(
+            '%s: %s. Created: %s',
+            $this->type,
+            $this->patient->getPatientLabel(),
+            date('Y-m-d H:i:s')
+        );
+    }
+
+    /**
+     * Render a template using the patient data
+     * @param  string $template The template name to render.
+     * @return string
+     */
+    protected function render(string $template) : string
+    {
+        $m = new \Mustache_Engine(array('entity_flags' => ENT_QUOTES));
+
+        $template_path = TEMPLATE_DIR . "{$this->template_path}/{$template}.mustache";
+
+        return $m->render(
+            file_get_contents($template_path),
+            $this->getPatientData()
+        );
+    }
+
+    /**
+     * Publish the events
+     * Cancel the any events that are not longer needed and push this event to the com calendar
+     */
+    public function publish() : void
+    {
+        // Can't send notfications if the order doesn't exist
+        if (!$this->patient) {
+            return;
+        }
+        $this->patient_label = $this->patient->getPatientLabel();
+        $this->publishEvent();
+    }
+}

--- a/classes/GoodPill/Events/Patient/NewPatientRegister.php
+++ b/classes/GoodPill/Events/Patient/NewPatientRegister.php
@@ -113,6 +113,7 @@ class NewPatientRegister extends Event
         }
 
         if (! is_null($this->groups)) {
+            $data['invoice_number'] = $this->groups['ALL'][0]['invoice_number'];
             $data['groups'] = $this->groups;
             $data['provider'] = [
                 'provider_first_name' => $this->groups['ALL'][0]['provider_first_name'],
@@ -213,10 +214,13 @@ class NewPatientRegister extends Event
         if (!$this->patient) {
             return;
         }
+        //  Should not need to ever call the `Needs Form` event again since all usage is replaced
+        //  With this event
         $this->patient->cancelEvents([
             'Needs Form',
             'Patient Registration'
         ]);
+
         $this->patient_label = $this->patient->getPatientLabel();
         $this->publishEvent();
     }

--- a/classes/GoodPill/Events/Patient/NewPatientRegister.php
+++ b/classes/GoodPill/Events/Patient/NewPatientRegister.php
@@ -55,7 +55,7 @@ class NewPatientRegister extends Event
      */
     public function __construct(?GpPatient $patient = null, $groups = null)
     {
-        $this->type = 'New Patient Register';
+        $this->type = 'Patient Registration';
         $this->groups = $groups;
 
         if (!is_null($patient)) {
@@ -213,6 +213,10 @@ class NewPatientRegister extends Event
         if (!$this->patient) {
             return;
         }
+        $this->patient->cancelEvents([
+            'Needs Form',
+            'Patient Registration'
+        ]);
         $this->patient_label = $this->patient->getPatientLabel();
         $this->publishEvent();
     }

--- a/classes/GoodPill/Events/Patient/RegistrationReminder.php
+++ b/classes/GoodPill/Events/Patient/RegistrationReminder.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace GoodPill\Events\Patient;
+
+use GoodPill\Events\Event;
+use GoodPill\Events\SalesforceComm;
+use GoodPill\Events\EmailComm;
+use GoodPill\Events\SmsComm;
+use GoodPill\Models\GpPatient;
+
+/**
+ * A Class to define the event when a CarepointPatientLabel has changed
+ */
+class RegistrationReminder extends NewPatientRegister
+{
+
+    /**
+     * Should be defined by Child class
+     * @var string
+     */
+    protected $template_path = 'Patient/RegistrationReminder';
+}

--- a/cronjobs/syncing.php
+++ b/cronjobs/syncing.php
@@ -394,6 +394,13 @@ try {
             CliLog::notice('Nothing to Queue orders_cp.updated');
         }
 
+        //  Process patients_cp.created after orders
+        if ($has_changes = get_sync_request('patients_cp', ['created'], $changes_to_patients_cp, $exec_id)) {
+            $changes_sqs_messages[] = $has_changes;
+        } else {
+            CliLog::notice('Nothing to Queue patients_cp.created');
+        }
+
 
         // Orders WC
         if ($has_changes = get_sync_request('orders_wc', ['created'], $changes_to_orders_wc, $exec_id)) {

--- a/templates/Patient/NewPatientRegister/email.mustache
+++ b/templates/Patient/NewPatientRegister/email.mustache
@@ -1,0 +1,13 @@
+<p>Welcome to Good Pill!  We are excited to fill your prescriptions.</p>
+<p>
+    Please take 5 minutes to register so that we can fill the Rxs we got from your doctor as soon as possible. <br>
+    Once you register it will take 5-7 business days before you receive your order. <br>
+    You can register online at www.goodpill.org or by calling us at (888) 987-5187.
+</p>
+<p>The drugs in your first order will be</p>
+<ul>
+    {{#order_items}}
+        <li>{{.}}</li>
+    {{/order_items}}
+</ul>
+

--- a/templates/Patient/NewPatientRegister/email.mustache
+++ b/templates/Patient/NewPatientRegister/email.mustache
@@ -1,5 +1,5 @@
 <p>Welcome to Good Pill!  We are excited to fill your prescriptions.</p>
-<p>
+<p>Your first order #{{invoice_number}} will cost $6, paid after you receive your medications.<br>
     Please take 5 minutes to register so that we can fill the Rxs we got from your doctor as soon as possible. <br>
     Once you register it will take 5-7 business days before you receive your order. <br>
     You can register online at www.goodpill.org or by calling us at (888) 987-5187.

--- a/templates/Patient/NewPatientRegister/email_subject.mustache
+++ b/templates/Patient/NewPatientRegister/email_subject.mustache
@@ -1,0 +1,1 @@
+Welcome to Good Pill!  We are excited to fill your prescriptions.

--- a/templates/Patient/NewPatientRegister/salesforce.mustache
+++ b/templates/Patient/NewPatientRegister/salesforce.mustache
@@ -1,0 +1,21 @@
+<p>Call to Register Patient</p>
+
+<ul>
+    <li>
+        If pt does not have a backup pharmacy in Salesforce, call them to register.
+    </li>
+    <li>
+        Attempt 2 calls/voicemails over 2 days. Even if the phone number is invalid, attempt a 2nd call.
+    </li>
+    <li>
+        After 2 failed attempts, reassign this task to .Flag Clinic/Provider Issue - Admin.
+    </li>
+</ul>
+
+<p>Provider Info:</p>
+{{#provider}}
+    {{provider_first_name}}<br>
+    {{provider_last_name}}<br>
+    {{provider_clinic}}<br>
+    {{provider_phone}}<br>
+{{/provider}}

--- a/templates/Patient/RegistrationReminder/email.mustache
+++ b/templates/Patient/RegistrationReminder/email.mustache
@@ -1,0 +1,13 @@
+<p>This is a reminder to register with Goodpill</p>
+<p>
+    Please take 5 minutes to register so that we can fill the Rxs we got from your doctor as soon as possible. <br>
+    Once you register it will take 5-7 business days before you receive your order. <br>
+    You can register online at www.goodpill.org or by calling us at (888) 987-5187.
+</p>
+<p>The drugs in your first order will be</p>
+<ul>
+    {{#order_items}}
+        <li>{{.}}</li>
+    {{/order_items}}
+</ul>
+

--- a/templates/Patient/RegistrationReminder/email_subject.mustache
+++ b/templates/Patient/RegistrationReminder/email_subject.mustache
@@ -1,0 +1,1 @@
+Reminder to Register With Good Pill

--- a/templates/Patient/RegistrationReminder/salesforce.mustache
+++ b/templates/Patient/RegistrationReminder/salesforce.mustache
@@ -1,0 +1,21 @@
+<p>Call to Register Patient</p>
+
+<ul>
+    <li>
+        If pt does not have a backup pharmacy in Salesforce, call them to register.
+    </li>
+    <li>
+        Attempt 2 calls/voicemails over 2 days. Even if the phone number is invalid, attempt a 2nd call.
+    </li>
+    <li>
+        After 2 failed attempts, reassign this task to .Flag Clinic/Provider Issue - Admin.
+    </li>
+</ul>
+
+<p>Provider Info:</p>
+{{#provider}}
+    {{provider_first_name}}<br>
+    {{provider_last_name}}<br>
+    {{provider_clinic}}<br>
+    {{provider_phone}}<br>
+{{/provider}}

--- a/updates/update_patients_cp.php
+++ b/updates/update_patients_cp.php
@@ -3,6 +3,7 @@
 require_once 'helpers/helper_full_patient.php';
 require_once 'helpers/helper_try_catch_log.php';
 
+use GoodPill\Events\Patient\NewPatientRegister;
 use GoodPill\Logging\{
     GPLog,
     AuditLog,
@@ -108,6 +109,8 @@ function update_patients_cp(array $changes) : void
         //TODO IF THIS WORKS MAKE THE CODE BELOW WORK WITH PATIENT MODEL
         //$groups = group_drugs($order, $mysql);
         //needs_form_notice($groups);
+        $register_event = new NewPatientRegister($gpPatient);
+        $register_event->publish();
     }
 
     GPLog::resetSubroutineId();

--- a/updates/update_patients_cp.php
+++ b/updates/update_patients_cp.php
@@ -95,20 +95,18 @@ function update_patients_cp(array $changes) : void
         return $created;
     }
 
-    //TODO See if this call can replace the needs_form_notice() call
-    //in both orders_created_cp and rxs_single_created2.  Or if not replace
-    //then these three calls can all have slightly different wording
     if ( ! $gpPatient->pharmacy_name) {
+        $mysql = new Mysql_Wc();
+        $patient_data = $gpPatient->getLegacyPatient();
 
+        //  @TODO - can group_drugs be used with a `load_full_patient` object?
+        $groups = group_drugs($patient_data, $mysql);
         GPLog::warning('Needs Form Notice for CP Patient Created without WC Registration (Pharmacy Name)', [
             'patient' => $gpPatient->attributesToArray(),
             'created' => $created,
             'changed' => $gpPatient->getChangeStrings()
         ]);
 
-        //TODO IF THIS WORKS MAKE THE CODE BELOW WORK WITH PATIENT MODEL
-        //$groups = group_drugs($order, $mysql);
-        //needs_form_notice($groups);
         $register_event = new NewPatientRegister($gpPatient);
         $register_event->publish();
     }


### PR DESCRIPTION
- Created two templates and event classes for new patient registration and registration reminders
- Replaced the `needs_form_notice` instances in update_orders_cp and update_rxs.
- Added the New Patient event under the cp_patients_created call.
- Modified syncing to send cp_patient.created changes to go to the queue for processing. This should happen after orders are processed
- Added checks to the patient reminder events to see if their account is older than 30 days and they still haven't registered