### PR TITLE
#zthwxx - Add Translations to Events

### DIFF
--- a/classes/GoodPill/Events/EmailComm.php
+++ b/classes/GoodPill/Events/EmailComm.php
@@ -3,6 +3,7 @@
 namespace GoodPill\Events;
 
 use GoodPill\Events\Comm;
+use GoodPill\Models\GpPatient;
 
 class EmailComm extends Comm
 {
@@ -13,7 +14,8 @@ class EmailComm extends Comm
         'subject',
         'bcc',
         'from',
-        'attachments'
+        'attachments',
+        'language'
     ];
 
     protected $required = [
@@ -31,6 +33,19 @@ class EmailComm extends Comm
     public function setAttachments(array $attachments)
     {
         $this->stored_data['attachments'] = $attachments;
+    }
+
+    /**
+     * Sets the language for the email to be translated to
+     * @param GpPatient $gpPatient
+     */
+    public function setLanguage(GpPatient $gpPatient)
+    {
+        $patient_language = strtoupper($gpPatient->language);
+
+        if ($patient_language && $patient_language !== 'EN') {
+            $this->stored_data['language'] = $patient_language;
+        }
     }
 
     /**

--- a/classes/GoodPill/Events/Order/OrderEvent.php
+++ b/classes/GoodPill/Events/Order/OrderEvent.php
@@ -191,6 +191,8 @@ abstract class OrderEvent extends Event
         $email->email       = DEBUG_EMAIL;
         //$email->email   = $this->order->patient->email;
 
+        $email->setLanguage($this->order->patient);
+
         return $email;
     }
 
@@ -210,6 +212,8 @@ abstract class OrderEvent extends Event
         // $sms->sms     = $patient->getPhonesAsString();
         $sms->sms     = DEBUG_PHONE;
         $sms->message = $this->render('sms');
+        $sms->setLanguage($patient);
+
         return $sms;
     }
 

--- a/classes/GoodPill/Events/SmsComm.php
+++ b/classes/GoodPill/Events/SmsComm.php
@@ -3,19 +3,34 @@
 namespace GoodPill\Events;
 
 use GoodPill\Events\Comm;
+use GoodPill\Models\GpPatient;
 
 class SmsComm extends Comm
 {
     protected $properties = [
         'message',
         'sms',
-        'fallbacks'
+        'fallbacks',
+        'language'
     ];
 
     protected $required = [
         'message',
         'sms',
     ];
+
+    /**
+     * Sets the language for the text to be translated to
+     * @param GpPatient $gpPatient
+     */
+    public function setLanguage(GpPatient $gpPatient)
+    {
+        $patient_language = strtoupper($gpPatient->language);
+
+        if ($patient_language && $patient_language !== 'EN') {
+            $this->stored_data['language'] = $patient_language;
+        }
+    }
 
     /**
      * Create a Comm Calendar compatible SMS message


### PR DESCRIPTION
- adds a `setLanguage` function that takes in a GpPatient model and add's the patient's language to the comms arrays
Example usage
- This could be rewritten to take in just the language code `EN`, `ES`, `FR` ect but then the logic to uppercase and only add it to the language property if it isn't english would need to be manually handled in each case

```
    public function getEmail() : ?EmailComm
    {
        $email              = new EmailComm();
        $email->subject     = $this->render('email_subject');
        $email->message     = $this->render('email');
        $email->email       = $this->patient->email;

        $email->setLanguage($this->patient);

        return $email;
    }
    