### PR TITLE
#xt7nyp - Manually Protect orders

### DIFF
--- a/updates/update_order_items.php
+++ b/updates/update_order_items.php
@@ -109,11 +109,6 @@ function order_item_created(array $created, array &$orders_updated) : ?array
 
     $GPOrder = GpOrder::where('invoice_number', $invoice_number)->first();
 
-    if ($GPOrder->order_source === 'Manually Protected')
-    {
-        GPLog::info("order_item_created: Blocking item creation for {$GPOrder->invoice_number}. It is protected");
-        return false;
-    }
     if ($GPOrder && $GPOrder->isShipped()) {
         GPLog::alert(
             "Trying to add an item to an order that has already shipped",
@@ -230,12 +225,6 @@ function order_item_deleted(array $deleted, array &$orders_updated) : ?array
     $invoice_number = $deleted['invoice_number'];
 
     $GPOrder = GpOrder::where('invoice_number', $invoice_number)->first();
-
-    if ($GPOrder->order_source === 'Manually Protected')
-    {
-        GPLog::info("order_item_deleted: Blocking item deletion for {$GPOrder->invoice_number}. It is protected");
-        return false;
-    }
 
     if ($GPOrder && $GPOrder->isShipped()) {
         GPLog::alert(

--- a/updates/update_order_items.php
+++ b/updates/update_order_items.php
@@ -108,6 +108,12 @@ function order_item_created(array $created, array &$orders_updated) : ?array
     $invoice_number = $created['invoice_number'];
 
     $GPOrder = GpOrder::where('invoice_number', $invoice_number)->first();
+
+    if ($GPOrder->order_source === 'Manually Protected')
+    {
+        GPLog::info("order_item_created: Blocking item creation for {$GPOrder->invoice_number}. It is protected");
+        return false;
+    }
     if ($GPOrder && $GPOrder->isShipped()) {
         GPLog::alert(
             "Trying to add an item to an order that has already shipped",
@@ -224,6 +230,13 @@ function order_item_deleted(array $deleted, array &$orders_updated) : ?array
     $invoice_number = $deleted['invoice_number'];
 
     $GPOrder = GpOrder::where('invoice_number', $invoice_number)->first();
+
+    if ($GPOrder->order_source === 'Manually Protected')
+    {
+        GPLog::info("order_item_deleted: Blocking item deletion for {$GPOrder->invoice_number}. It is protected");
+        return false;
+    }
+
     if ($GPOrder && $GPOrder->isShipped()) {
         GPLog::alert(
             "Trying to delete an item to an order that has already shipped",

--- a/updates/update_orders_cp.php
+++ b/updates/update_orders_cp.php
@@ -169,6 +169,16 @@ function cp_order_created(array $created) : ?array
         return null;
     }
 
+    //  If we skipped the duplicate order check, check to see if it's protected and log if so
+    if ($created['order_source'] === 'Manually Protected')
+    {
+        GPLog::warning('cp_order_updated: Manually Protected, skip export_cp_remove_order',
+            [
+                'invoice_number' => $created['invoice_number'],
+                'created' => $created
+            ]
+        );
+    }
     // Overwrite Rx Messages everytime a new order created otherwise
     // same message would stay for the life of the Rx
     $order = load_full_order($created, $mysql, true);
@@ -330,6 +340,13 @@ function cp_order_created(array $created) : ?array
         if ($order[0]['order_source'] !== 'Manually Protected')
         {
             export_cp_remove_order($order[0]['invoice_number'], $reason);
+        } else {
+            GPLog::warning('cp_order_created: Manually Protected, skip export_cp_remove_order',
+                [
+                    'invoice_number' => $order[0]['invoice_number'],
+                    'order' => $order
+                ]
+            );
         }
 
         if (is_webform($order[0])) {
@@ -404,6 +421,13 @@ function cp_order_deleted(array $deleted) : ?array
     if ($deleted['order_source'] !== 'Manually Protected')
     {
         export_cp_remove_items($deleted['invoice_number']);
+    } else {
+        GPLog::warning('cp_order_deleted: Manually Protected, skip export_cp_remove_items',
+            [
+                'invoice_number' => $deleted['invoice_number'],
+                'deleted' => $deleted
+            ]
+        );
     }
 
     export_gd_delete_invoice($deleted['invoice_number']);
@@ -779,6 +803,17 @@ function cp_order_updated(array $updated) : ?array
         }
 
         return null;
+    }
+
+    //  If we skipped the conditional above, check for manually protected and log if true
+    if ($order[0]['order_source'] === 'Manually Protected')
+    {
+        GPLog::warning('cp_order_updated: Manually Protected, skip export_cp_remove_order',
+            [
+                'invoice_number' => $order[0]['invoice_number'],
+                'order' => $order
+            ]
+        );
     }
 
     //Address Changes

--- a/updates/update_orders_cp.php
+++ b/updates/update_orders_cp.php
@@ -106,12 +106,15 @@ function cp_order_created(array $created) : ?array
         return null;
     }
 
-    if (count($duplicate) > 1
+    if (
+        count($duplicate) > 1
         && $duplicate[0]['invoice_number'] != $created['invoice_number']
         && (
           ! is_webform($created)
           || is_webform($duplicate[0])
-        )) {
+        )
+        && $created['order_source'] !== 'Manually Protected'
+    ) {
         GPLog::warning(
             sprintf(
                 "Created Carepoint Order Seems to be a duplicate %s >>> %s",
@@ -146,15 +149,10 @@ function cp_order_created(array $created) : ?array
         );
 
         //  There is a deletion that happens inside this merge_orders function
-        if (
-            $created['order_source'] !== 'Manually Protected'
-        )
-        {
-            export_cp_merge_orders(
-                $created['invoice_number'],
-                $duplicate[0]['invoice_number']
-            );
-        }
+        export_cp_merge_orders(
+            $created['invoice_number'],
+            $duplicate[0]['invoice_number']
+        );
 
         if (is_webform($created)) {
             export_wc_cancel_order(

--- a/updates/update_orders_cp.php
+++ b/updates/update_orders_cp.php
@@ -147,8 +147,7 @@ function cp_order_created(array $created) : ?array
 
         //  There is a deletion that happens inside this merge_orders function
         if (
-            isset($created['order_source']) &&
-            $created['order_source'] === 'Manually Protected'
+            $created['order_source'] !== 'Manually Protected'
         )
         {
             export_cp_merge_orders(


### PR DESCRIPTION
- Add check on the order_source when an order is being deleted or items added/removed to prevent any of that from happening