### PR TITLE
#xt7nur - Refill Reminder Event

### DIFF
--- a/classes/GoodPill/Events/Event.php
+++ b/classes/GoodPill/Events/Event.php
@@ -67,7 +67,8 @@ abstract class Event
         }
 
         // TODO Replace this with a new object based Event
-        create_event($title, $comm_array, $this->hours_to_wait, $this->hour_of_day);
+        print_r($comm_array);
+        //create_event($title, $comm_array, $this->hours_to_wait, $this->hour_of_day);
     }
 
     /**

--- a/classes/GoodPill/Events/Order/OrderEvent.php
+++ b/classes/GoodPill/Events/Order/OrderEvent.php
@@ -130,24 +130,33 @@ abstract class OrderEvent extends Event
             }
 
             /*************** Refill Reminder Data ******************/
-            $refill = $this->order->getItemsWithNoRefills();
-            $autofill = $this->order->getItemsWithNoAutofills();
+            $no_refills = $this->order->getItemsInGroupWithNoRefills();
+            $no_autofill = $this->order->getItemsInGroupWithNoAutofills();
 
-            if ($autofill->count() > 0) {
+            if ($no_autofill->count() > 0) {
                 $rxs = [];
 
-                $autofill->each(function($item) use (&$rxs) {
-                    $rxs[] = ["name" => $item->getDrugName().' - '.$item->getPatientMessageText()];
+                $no_autofill->each(function($item) use (&$rxs) {
+                    $rxs[] = [
+                        'name' => $item->getDrugName(),
+                        'patient_message_text' => $item->getPatientMessageText(),
+                        'rx_number' => $item->rx_number,
+
+                    ];
                 });
 
                $data['no_autofill'] = ['rxs' => $rxs];
             }
 
-            if ($refill->count() > 0) {
+            if ($no_refills->count() > 0) {
                 $rxs = [];
 
-                $refill->each(function($item) use (&$rxs) {
-                    $rxs[] = ["name" => $item->getDrugName().' - '.$item->getPatientMessageText()];
+                $no_refills->each(function($item) use (&$rxs) {
+                    $rxs[] = [
+                        'name' => $item->getDrugName(),
+                        'patient_message_text' => $item->getPatientMessageText(),
+                        'rx_number' => $item->rx_number,
+                    ];
                 });
 
                 $data['no_refill'] = ['rxs' => $rxs];

--- a/classes/GoodPill/Events/Order/OrderEvent.php
+++ b/classes/GoodPill/Events/Order/OrderEvent.php
@@ -137,7 +137,7 @@ abstract class OrderEvent extends Event
                 $rxs = [];
 
                 $autofill->each(function($item) use (&$rxs) {
-                    $rxs[] = ["name" => $item->getDrugName().' - '.$item->rxs->rx_message_text];
+                    $rxs[] = ["name" => $item->getDrugName().' - '.$item->getPatientMessageText()];
                 });
 
                $data['no_autofill'] = ['rxs' => $rxs];
@@ -147,7 +147,7 @@ abstract class OrderEvent extends Event
                 $rxs = [];
 
                 $refill->each(function($item) use (&$rxs) {
-                    $rxs[] = ["name" => $item->getDrugName().' - '.$item->rxs->rx_message_text];
+                    $rxs[] = ["name" => $item->getDrugName().' - '.$item->getPatientMessageText()];
                 });
 
                 $data['no_refill'] = ['rxs' => $rxs];

--- a/classes/GoodPill/Events/Order/RefillReminder.php
+++ b/classes/GoodPill/Events/Order/RefillReminder.php
@@ -25,14 +25,12 @@ class RefillReminder extends OrderEvent
     /**
      * RefillReminder constructor.
      * @param $GpOrder
-     * @param int $hours_to_wait
-     * @param string $time_of_day
      */
-    public function __construct(GpOrder $GpOrder, int $hours_to_wait = 30, string $time_of_day = '11:00')
+    public function __construct(GpOrder $GpOrder)
     {
         parent::__construct($GpOrder);
-        $this->hours_to_wait = $hours_to_wait;
-        $this->time_of_day = $time_of_day;
+        $this->hours_to_wait = $GpOrder->getDaysBeforeOutOfRefills() * 24;
+        $this->time_of_day = '11:00';
     }
 
     /**

--- a/classes/GoodPill/Events/Order/RefillReminder.php
+++ b/classes/GoodPill/Events/Order/RefillReminder.php
@@ -53,6 +53,6 @@ class RefillReminder extends OrderEvent
     {
         //  @TODO Uncomment this out when going live
         //  $this->order->cancelEvents(['Refill Reminder']);
-        $this->publishEvent();
+        //$this->publishEvent();
     }
 }

--- a/classes/GoodPill/Models/GpOrderItem.php
+++ b/classes/GoodPill/Models/GpOrderItem.php
@@ -407,6 +407,22 @@ class GpOrderItem extends Model
     }
 
     /**
+     * Parses and formats message text on an order item
+     * @return string
+     */
+    public function getPatientMessageText() : string
+    {
+        if (!empty($this->item_message_text)) {
+            $message = $this->item_message_text;
+        } else {
+            $rxs = $this->rxs;
+            $message = $rxs->rx_message_text;
+        }
+
+        return str_replace(' **', '', $message);
+    }
+
+    /**
      * A convenient way for setting the pickelist on an item.  This is here to overcome the
      * shortcomings of v2.  V2 fails to load on certain URLS, so this allows us to pass in the
      * calculated picklist

--- a/exports/export_gd_comm_calendar.php
+++ b/exports/export_gd_comm_calendar.php
@@ -93,19 +93,26 @@ function order_shipped_notice($groups)
 
 function refill_reminder_notice($groups)
 {
+    $gpOrder = GpOrder::where('invoice_number', $groups['ALL'][0]['invoice_number'])->first();
+
+    if ($gpOrder) {
+        $days = $gpOrder->getDaysBeforeOutOfRefills();
+
+        GPLog::notice("Comparing MIN_DAYS to getDaysBeforeOutOfRefills", [
+            'groups' => $groups,
+            'MIN_DAYS' => $groups['MIN_DAYS'],
+            'days' => $days,
+        ]);
+        //  @TODO - Make live
+        // $event = new RefillReminder($gpOrder, $groups['MIN_DAYS']*24, '11:00');
+        // $event->publishEvent();
+    }
+
     if ($groups['MIN_DAYS'] == 366 or (! count($groups['NO_REFILLS']) and ! count($groups['NO_AUTOFILL']))) {
         GPLog::notice("Not making a refill_reminder_notice", $groups);
         return;
     }
-    /*
-     * Commentend out until ready to make live
-    $gpOrder = GpOrder::where('invoice_number', $groups['ALL'][0]['invoice_number'])->first();
 
-    if ($gpOrder) {
-        // $shipping_event = new RefillReminder($gpOrder, $groups['MIN_DAYS']*24, '11:00');
-        // $shipping_event->publishEvent();
-    }
-    */
     $subject  = 'Good Pill cannot refill these Rxs without your help.';
     $message  = '';
 

--- a/templates/Order/Refill_reminder/email.mustache
+++ b/templates/Order/Refill_reminder/email.mustache
@@ -63,7 +63,7 @@
         <u>We need a new Rx for the following:</u>
     <ul>
         {{# rxs }}
-            <li>{{ name }}</li>
+            <li>{{ name }} - {{ patient_message_text }}</li>
         {{/ rxs }}
     </ul>
     </p>
@@ -74,7 +74,7 @@
         <u>These Rxs will NOT be filled automatically and must be requested 2 weeks in advance:</u>
     <ul>
         {{# rxs }}
-            <li>{{ name }}</li>
+            <li>{{ name }} - {{ patient_message_text }}</li>
         {{/ rxs }}
     </ul>
     </p>


### PR DESCRIPTION
Refill Reminder event

- New methods for calculating min_days, and some $groups['NO_AUTOFILL'], and $groups['NO_REFILLS']
- adds new data to OrderEvent and separated the drug names from patient text messaging
- Adds a log on the refill_reminder_notice to log the MIN days from $groups and the new calculated days to verify that they are the same