### PR TITLE
fix undefined variable for v2 pending

### DIFF
--- a/exports/export_v2_order.php
+++ b/exports/export_v2_order.php
@@ -17,7 +17,7 @@ function v2_unpend_order_by_invoice(int $invoice_number, ?array $pend_params = n
             );
 
             // Remove the Pendgroup record incase we need to pend i as a new group
-            $pend_group = GpPendGroup::where('invoice_number', $item['invoice_number'])->first();
+            $pend_group = GpPendGroup::where('invoice_number', $invoice_number)->first();
 
             if ($pend_group) {
                 $pend_group->delete();


### PR DESCRIPTION
Small error I came across. I think because there isn't an item, there is never a pendgroup found to delete. This likely would only cause entries in the `gp_pend_group` to not be deleted when an order is unpended.

Feel free to close the PR if this is an unnecessary fix